### PR TITLE
feat(pi-cursor-agent): Inject pi context as cursor rules

### DIFF
--- a/pi-cursor-agent/package-lock.json
+++ b/pi-cursor-agent/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
         "@connectrpc/connect": "^1.7.0",
-        "@connectrpc/connect-node": "^1.7.0"
+        "@connectrpc/connect-node": "^1.7.0",
+        "yaml": "^2.8.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.2",

--- a/pi-cursor-agent/package.json
+++ b/pi-cursor-agent/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@bufbuild/protobuf": "1.10.0",
     "@connectrpc/connect": "^1.7.0",
-    "@connectrpc/connect-node": "^1.7.0"
+    "@connectrpc/connect-node": "^1.7.0",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.2",

--- a/pi-cursor-agent/src/bridge/cursor-to-pi/executors/request-context.ts
+++ b/pi-cursor-agent/src/bridge/cursor-to-pi/executors/request-context.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import type { CursorRule } from "../../../__generated__/agent/v1/cursor_rules_pb";
 import type { McpToolDefinition } from "../../../__generated__/agent/v1/mcp_pb";
 import { GitRepoInfo } from "../../../__generated__/agent/v1/repo_pb";
 import type { RequestContextArgs } from "../../../__generated__/agent/v1/request_context_exec_pb";
@@ -23,11 +24,17 @@ export class LocalRequestContextExecutor
 {
   private readonly tools: McpToolDefinition[];
   private readonly workspacePaths: string[];
+  private readonly rules: CursorRule[];
   private readonly gitExecutor: LocalGitExecutor;
 
-  constructor(tools: McpToolDefinition[], workspacePaths: string[]) {
+  constructor(
+    tools: McpToolDefinition[],
+    workspacePaths: string[],
+    rules: CursorRule[] = [],
+  ) {
     this.tools = tools;
     this.workspacePaths = workspacePaths;
+    this.rules = rules;
     this.gitExecutor = new LocalGitExecutor();
   }
 
@@ -42,7 +49,7 @@ export class LocalRequestContextExecutor
       ]);
 
       const requestContext = new RequestContext({
-        rules: [],
+        rules: this.rules,
         env,
         repositoryInfo: [],
         tools: this.tools,

--- a/pi-cursor-agent/src/bridge/cursor-to-pi/local-resource-provider/provider.ts
+++ b/pi-cursor-agent/src/bridge/cursor-to-pi/local-resource-provider/provider.ts
@@ -1,3 +1,4 @@
+import type { CursorRule } from "../../../__generated__/agent/v1/cursor_rules_pb";
 import type { McpToolDefinition } from "../../../__generated__/agent/v1/mcp_pb";
 import {
   backgroundShellResource,
@@ -46,6 +47,7 @@ interface LocalResourceProviderOptions {
   ctx: PiToolContext;
   requestContextTools?: McpToolDefinition[];
   workspacePaths?: string[];
+  cursorRules?: CursorRule[];
 }
 
 export class LocalResourceProvider extends RegistryResourceAccessor {
@@ -63,6 +65,7 @@ export class LocalResourceProvider extends RegistryResourceAccessor {
       new LocalRequestContextExecutor(
         requestContextTools,
         resolvedWorkspacePaths,
+        options.cursorRules ?? [],
       ),
     );
 

--- a/pi-cursor-agent/src/bridge/pi-context/index.ts
+++ b/pi-cursor-agent/src/bridge/pi-context/index.ts
@@ -1,0 +1,16 @@
+import type { CursorRule } from "../../__generated__/agent/v1/cursor_rules_pb";
+import { parsePiSystemPrompt } from "./parser";
+import { buildCursorRules } from "./rules-builder";
+
+export interface PreparedPiContext {
+  rules: CursorRule[];
+  cleanedPrompt: string;
+}
+
+export async function preparePiContext(
+  systemPrompt: string,
+): Promise<PreparedPiContext> {
+  const parsed = parsePiSystemPrompt(systemPrompt);
+  const rules = await buildCursorRules(parsed);
+  return { rules, cleanedPrompt: parsed.cleanedPrompt };
+}

--- a/pi-cursor-agent/src/bridge/pi-context/parser.ts
+++ b/pi-cursor-agent/src/bridge/pi-context/parser.ts
@@ -1,0 +1,115 @@
+/** Parse Pi system prompt into structured components for Cursor's RequestContext.rules. */
+
+export interface PiContextFile {
+  path: string;
+  content: string;
+}
+
+export interface PiSkillRef {
+  name: string;
+  description: string;
+  location: string;
+}
+
+export interface ParsedPiContext {
+  contextFiles: PiContextFile[];
+  skills: PiSkillRef[];
+  cleanedPrompt: string;
+}
+
+// Stable structural markers only — no description text that may change across Pi versions.
+const CONTEXT_HEADING = "# Project Context";
+const SKILLS_OPEN = "<available_skills>";
+const SKILLS_CLOSE = "</available_skills>";
+
+const SKILL_RE =
+  /<skill>\s*<name>([\s\S]*?)<\/name>\s*<description>([\s\S]*?)<\/description>\s*<location>([\s\S]*?)<\/location>\s*<\/skill>/g;
+
+function unescapeXml(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function extractContextFiles(prompt: string): PiContextFile[] {
+  const start = prompt.indexOf(CONTEXT_HEADING);
+  if (start === -1) return [];
+
+  let end = prompt.length;
+  for (const marker of [SKILLS_OPEN, "\nCurrent date: "]) {
+    const idx = prompt.indexOf(marker, start);
+    if (idx !== -1 && idx < end) end = idx;
+  }
+
+  return prompt
+    .slice(start, end)
+    .split(/^(?=## \/)/m)
+    .slice(1)
+    .flatMap((block) => {
+      const nl = block.indexOf("\n");
+      if (nl === -1) return [];
+      const path = block.slice(3, nl).trim();
+      const content = block.slice(nl + 1).trim();
+      return path && content ? [{ path, content }] : [];
+    });
+}
+
+function extractSkills(prompt: string): PiSkillRef[] {
+  const openIdx = prompt.indexOf(SKILLS_OPEN);
+  if (openIdx === -1) return [];
+
+  const closeIdx = prompt.indexOf(SKILLS_CLOSE, openIdx);
+  if (closeIdx === -1) return [];
+
+  const xml = prompt.slice(openIdx, closeIdx + SKILLS_CLOSE.length);
+  const skills: PiSkillRef[] = [];
+
+  for (const m of xml.matchAll(SKILL_RE)) {
+    if (!m[1] || !m[2] || !m[3]) continue;
+    const name = unescapeXml(m[1].trim());
+    const description = unescapeXml(m[2].trim());
+    const location = unescapeXml(m[3].trim());
+    if (name && description && location) {
+      skills.push({ name, description, location });
+    }
+  }
+
+  return skills;
+}
+
+const PRESERVED_PATTERNS = [
+  /^Pi documentation[^\n]*(?:\n- [^\n]*)*/m,
+  /^Current date: .+$/m,
+  /^Current working directory: .+$/m,
+];
+
+function buildCleanedPrompt(original: string, hasExtracted: boolean): string {
+  const lines = PRESERVED_PATTERNS.map((re) => original.match(re)?.[0]).filter(
+    (s): s is string => s != null,
+  );
+
+  return lines.length === 0 && !hasExtracted ? original : lines.join("\n");
+}
+
+export function parsePiSystemPrompt(systemPrompt: string): ParsedPiContext {
+  if (!systemPrompt) {
+    return { contextFiles: [], skills: [], cleanedPrompt: "" };
+  }
+
+  try {
+    const contextFiles = extractContextFiles(systemPrompt);
+    const skills = extractSkills(systemPrompt);
+    const hasExtracted = contextFiles.length > 0 || skills.length > 0;
+
+    return {
+      contextFiles,
+      skills,
+      cleanedPrompt: buildCleanedPrompt(systemPrompt, hasExtracted),
+    };
+  } catch {
+    return { contextFiles: [], skills: [], cleanedPrompt: systemPrompt };
+  }
+}

--- a/pi-cursor-agent/src/bridge/pi-context/rules-builder.ts
+++ b/pi-cursor-agent/src/bridge/pi-context/rules-builder.ts
@@ -1,0 +1,73 @@
+/** Convert parsed Pi context into CursorRule[] for Cursor's RequestContext.rules. */
+
+import { readFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
+import {
+  CursorRule,
+  CursorRuleType,
+  CursorRuleTypeAgentFetched,
+  CursorRuleTypeGlobal,
+} from "../../__generated__/agent/v1/cursor_rules_pb";
+import type { ParsedPiContext, PiSkillRef } from "./parser";
+
+function parseFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const s = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!s.startsWith("---")) return { frontmatter: {}, body: s };
+
+  const end = s.indexOf("\n---", 3);
+  if (end === -1) return { frontmatter: {}, body: s };
+
+  const parsed = parseYaml(s.slice(4, end));
+  return {
+    frontmatter: (parsed ?? {}) as Record<string, unknown>,
+    body: s.slice(end + 4).trim(),
+  };
+}
+
+function globalRule(path: string, content: string): CursorRule {
+  return new CursorRule({
+    fullPath: path,
+    content,
+    type: new CursorRuleType({
+      type: { case: "global", value: new CursorRuleTypeGlobal() },
+    }),
+  });
+}
+
+function agentFetchedRuleType(description: string): CursorRuleType {
+  return new CursorRuleType({
+    type: {
+      case: "agentFetched",
+      value: new CursorRuleTypeAgentFetched({ description }),
+    },
+  });
+}
+
+async function agentFetchedRule(skill: PiSkillRef): Promise<CursorRule> {
+  try {
+    const raw = await readFile(skill.location, "utf-8");
+    const { body } = parseFrontmatter(raw);
+    return new CursorRule({
+      fullPath: skill.location,
+      content: body || raw,
+      type: agentFetchedRuleType(skill.description),
+    });
+  } catch {
+    return new CursorRule({
+      fullPath: skill.location,
+      content: skill.description,
+      type: agentFetchedRuleType(skill.description),
+    });
+  }
+}
+
+export async function buildCursorRules(
+  parsed: ParsedPiContext,
+): Promise<CursorRule[]> {
+  const globals = parsed.contextFiles.map((f) => globalRule(f.path, f.content));
+  const skills = await Promise.all(parsed.skills.map(agentFetchedRule));
+  return [...globals, ...skills];
+}

--- a/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
+++ b/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
@@ -234,6 +234,7 @@ interface BuildRunRequestParams {
   conversationState: ConversationStateStructure | undefined;
   mcpToolDefinitions?: McpToolDefinition[];
   state?: CursorStateStore;
+  systemPromptOverride?: string;
 }
 
 interface BuildRunRequestResult {
@@ -244,9 +245,14 @@ interface BuildRunRequestResult {
 export function buildRunRequest(
   params: BuildRunRequestParams,
 ): BuildRunRequestResult {
+  const content =
+    params.systemPromptOverride ??
+    params.context.systemPrompt ??
+    "You are a helpful assistant.";
+
   const systemPromptJson = JSON.stringify({
     role: "system",
-    content: params.context.systemPrompt || "You are a helpful assistant.",
+    content: content,
   });
   const systemPromptBytes = new TextEncoder().encode(systemPromptJson);
   const systemPromptId = getBlobId(systemPromptBytes);

--- a/pi-cursor-agent/src/provider/stream.ts
+++ b/pi-cursor-agent/src/provider/stream.ts
@@ -28,6 +28,7 @@ import {
   rejectPendingForSession,
   type ToolExecRequest,
 } from "../bridge/cursor-to-pi/tool-bridge";
+import { preparePiContext } from "../bridge/pi-context";
 import {
   buildRunRequest,
   getContextTools,
@@ -396,9 +397,12 @@ export function streamCursorAgent(
           getChannel: () => channel,
         };
 
+        const piContext = await preparePiContext(context.systemPrompt ?? "");
+
         const resources = new LocalResourceProvider({
           ctx: piToolCtx,
           requestContextTools,
+          cursorRules: piContext.rules,
         });
 
         const blobStore = agentStore.getBlobStore();
@@ -412,6 +416,7 @@ export function streamCursorAgent(
           conversationState: agentStore.getConversationStateStructure(),
           mcpToolDefinitions: requestContextTools,
           state: overlayState,
+          systemPromptOverride: piContext.cleanedPrompt,
         });
         agentStore.conversationStateStructure = conversationState;
 

--- a/pi-cursor-agent/test/bridge/pi-context/parser.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-context/parser.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parsePiSystemPrompt } from "../../../src/bridge/pi-context/parser";
+
+const PI_DOCS_BLOCK = [
+  "Pi documentation (read only when the user asks about pi itself):",
+  "- Main documentation: /path/to/pi-0.64.0/lib/pi/README.md",
+  "- Additional docs: /path/to/pi-0.64.0/lib/pi/docs",
+].join("\n");
+
+function buildPrompt(
+  opts: {
+    contextFiles?: { path: string; content: string }[];
+    skills?: { name: string; description: string; location: string }[];
+    contextDescription?: string;
+    skillsIntro?: string;
+    piDocs?: boolean;
+  } = {},
+): string {
+  let p =
+    "You are an expert coding assistant.\n\nAvailable tools:\n- read\n- bash";
+
+  if (opts.piDocs) p += `\n\n${PI_DOCS_BLOCK}`;
+
+  if (opts.contextFiles?.length) {
+    const desc =
+      opts.contextDescription ??
+      "Project-specific instructions and guidelines:";
+    p += `\n\n# Project Context\n\n${desc}\n\n`;
+    for (const f of opts.contextFiles) p += `## ${f.path}\n\n${f.content}\n\n`;
+  }
+
+  if (opts.skills?.length) {
+    const intro =
+      opts.skillsIntro ??
+      "The following skills provide specialized instructions.";
+    p += `\n${intro}\n\n<available_skills>`;
+    for (const s of opts.skills) {
+      p += `\n  <skill><name>${s.name}</name><description>${s.description}</description><location>${s.location}</location></skill>`;
+    }
+    p += "\n</available_skills>";
+  }
+
+  p += "\nCurrent date: 2026-03-30";
+  p += "\nCurrent working directory: /test/project";
+  return p;
+}
+
+test("extracts context files and skills", () => {
+  const result = parsePiSystemPrompt(
+    buildPrompt({
+      contextFiles: [
+        { path: "/global/AGENTS.md", content: "Global rules." },
+        { path: "/project/AGENTS.md", content: "Project rules." },
+      ],
+      skills: [
+        {
+          name: "react",
+          description: "React guide.",
+          location: "/skills/react/SKILL.md",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(result.contextFiles.length, 2);
+  assert.equal(result.contextFiles[0]?.path, "/global/AGENTS.md");
+  assert.ok(result.contextFiles[0]?.content.includes("Global rules."));
+  assert.equal(result.contextFiles[1]?.path, "/project/AGENTS.md");
+  assert.ok(result.contextFiles[1]?.content.includes("Project rules."));
+  assert.equal(result.skills.length, 1);
+  assert.equal(result.skills[0]?.name, "react");
+});
+
+test("cleanedPrompt keeps metadata and Pi documentation", () => {
+  const result = parsePiSystemPrompt(
+    buildPrompt({
+      contextFiles: [{ path: "/AGENTS.md", content: "x" }],
+      piDocs: true,
+    }),
+  );
+
+  assert.ok(result.cleanedPrompt.includes("Current date:"));
+  assert.ok(result.cleanedPrompt.includes("Current working directory:"));
+  assert.ok(result.cleanedPrompt.includes("Pi documentation"));
+  assert.ok(result.cleanedPrompt.includes("- Main documentation:"));
+  assert.ok(!result.cleanedPrompt.includes("Available tools:"));
+});
+
+test("returns empty for prompt without context or skills", () => {
+  const result = parsePiSystemPrompt(buildPrompt());
+  assert.deepEqual(result.contextFiles, []);
+  assert.deepEqual(result.skills, []);
+});
+
+test("resilient to changed description and intro text", () => {
+  const result = parsePiSystemPrompt(
+    buildPrompt({
+      contextFiles: [{ path: "/AGENTS.md", content: "Still works." }],
+      skills: [{ name: "s", description: "d", location: "/SKILL.md" }],
+      contextDescription: "Completely rewritten description in future Pi:",
+      skillsIntro: "Totally different skills intro paragraph.",
+    }),
+  );
+
+  assert.equal(result.contextFiles.length, 1);
+  assert.ok(result.contextFiles[0]?.content.includes("Still works."));
+  assert.equal(result.skills.length, 1);
+  assert.equal(result.skills[0]?.name, "s");
+});
+
+test("ignores non-path ## headings inside context file content", () => {
+  const result = parsePiSystemPrompt(
+    buildPrompt({
+      contextFiles: [
+        {
+          path: "/project/AGENTS.md",
+          content: "Instructions\n\n## Commands\n\nRun tests.",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(result.contextFiles.length, 1);
+  assert.equal(result.contextFiles[0]?.path, "/project/AGENTS.md");
+  assert.ok(result.contextFiles[0]?.content.includes("## Commands"));
+  assert.ok(result.contextFiles[0]?.content.includes("Run tests."));
+});
+
+test("unescapes XML entities in skill data", () => {
+  const result = parsePiSystemPrompt(
+    buildPrompt({
+      skills: [
+        {
+          name: "t",
+          description: "&lt;html&gt; &amp; &quot;q&quot;",
+          location: "/SKILL.md",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(result.skills[0]?.description, '<html> & "q"');
+});

--- a/pi-cursor-agent/test/bridge/pi-context/rules-builder.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-context/rules-builder.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ParsedPiContext } from "../../../src/bridge/pi-context/parser";
+import { buildCursorRules } from "../../../src/bridge/pi-context/rules-builder";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-cursor-rules-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function parsed(overrides: Partial<ParsedPiContext> = {}): ParsedPiContext {
+  return { contextFiles: [], skills: [], cleanedPrompt: "", ...overrides };
+}
+
+test("context files become global rules, skills become agentFetched rules", async () => {
+  await withTempDir(async (dir) => {
+    const skillPath = join(dir, "SKILL.md");
+    await writeFile(
+      skillPath,
+      "---\nname: s\ndescription: d\n---\nSkill body.",
+    );
+
+    const rules = await buildCursorRules(
+      parsed({
+        contextFiles: [{ path: "/AGENTS.md", content: "Agent rules." }],
+        skills: [{ name: "s", description: "d", location: skillPath }],
+      }),
+    );
+
+    assert.equal(rules.length, 2);
+    assert.equal(rules[0]?.type?.type.case, "global");
+    assert.equal(rules[0]?.content, "Agent rules.");
+    assert.equal(rules[1]?.type?.type.case, "agentFetched");
+    assert.equal(rules[1]?.content, "Skill body.");
+    assert.ok(!rules[1]?.content.includes("---"));
+  });
+});
+
+test("falls back to description when skill file is unreadable", async () => {
+  const rules = await buildCursorRules(
+    parsed({
+      skills: [
+        {
+          name: "gone",
+          description: "Skill description fallback.",
+          location: "/nonexistent/SKILL.md",
+        },
+      ],
+    }),
+  );
+
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0]?.type?.type.case, "agentFetched");
+  assert.equal(rules[0]?.content, "Skill description fallback.");
+});
+
+test("returns empty for empty context", async () => {
+  assert.deepEqual(await buildCursorRules(parsed()), []);
+});


### PR DESCRIPTION
## Summary

- Fixes #11
- Fixed an issue where AGENTS.md, Skills, etc. were not being passed to pi-cursor-agent.
- pi passes the entire System Context to the Extension at once and does not pass structured data, which makes the parsing unstable.
- Currently, it is implemented to parse this using regular expressions to extract the Context and Skills areas, and in the case of Skills, to read the entire content and pass it to the Cursor.