### PR TITLE
feat(pi-kilocode): show all provider models, not only free ones

### DIFF
--- a/pi-kilocode/README.md
+++ b/pi-kilocode/README.md
@@ -9,7 +9,7 @@ Use [Kilo Code](https://kilo.ai/)'s gateway directly from pi through Kilo's Open
 - Uses Kilo Gateway's OpenAI-compatible endpoint
 - Fetches the Kilo model catalog from `https://api.kilo.ai/api/gateway/models`
 - Caches the raw model response on disk
-- Registers **free text-capable models only**
+- Registers all text-capable models from the Kilo catalog
 - Supports anonymous usage for free models and browser-based Kilo login
 
 ## Installation
@@ -44,8 +44,6 @@ According to Kilo's public gateway documentation and behavior:
 
 ## Current limitations
 
-- Only **free** models are currently registered in pi
-- Paid models are not currently exposed in the `/model` list
 - Image-output-only models are intentionally hidden
 
 ## Requirements

--- a/pi-kilocode/src/provider/models.ts
+++ b/pi-kilocode/src/provider/models.ts
@@ -150,14 +150,10 @@ export function convertToPiModels(raw: KiloModel[]): ProviderModelConfig[] {
     .map(toPiModel);
 }
 
-export function filterFreeModels(raw: KiloModel[]): KiloModel[] {
-  return raw.filter((m) => m.isFree);
-}
-
 let updateInFlight: Promise<void> | null = null;
 
 export function getCachedPiModels(): ProviderModelConfig[] {
-  return convertToPiModels(filterFreeModels(readCache()?.data.data ?? []));
+  return convertToPiModels(readCache()?.data.data ?? []);
 }
 
 async function updateCachedPiModels() {

--- a/pi-kilocode/test/index.test.ts
+++ b/pi-kilocode/test/index.test.ts
@@ -55,7 +55,7 @@ function createMockPi() {
   return { api: api as unknown as ExtensionAPI, providerCalls, handlers };
 }
 
-test("registers kilocode provider once and refreshes cache from live raw response using only free models on demand", async (t) => {
+test("registers kilocode provider once and refreshes cache from live raw response on demand", async (t) => {
   resetPiKilocodeModelCacheForTests();
 
   const hadCache = fs.existsSync(PI_KILOCODE_MODELS_CACHE_FILE);
@@ -195,7 +195,7 @@ test("registers kilocode provider once and refreshes cache from live raw respons
 
   assert.deepEqual(
     getCachedPiModels().map((model) => model.id),
-    ["demo/free-model:free"],
+    ["demo/paid-model", "demo/free-model:free"],
   );
 
   assert.equal(pi.providerCalls.length, 1);

--- a/pi-kilocode/test/models.test.ts
+++ b/pi-kilocode/test/models.test.ts
@@ -1,56 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { convertToPiModels, filterFreeModels } from "../src/provider/models";
-
-test("filterFreeModels keeps only models with isFree=true", () => {
-  const filtered = filterFreeModels([
-    {
-      id: "demo/paid",
-      name: "Paid",
-      created: 1,
-      description: "Paid",
-      context_length: 1000,
-      architecture: {
-        input_modalities: ["text"],
-        output_modalities: ["text"],
-        tokenizer: "Other",
-      },
-      pricing: { prompt: "0.1", completion: "0.2" },
-      top_provider: {
-        is_moderated: false,
-        context_length: 1000,
-        max_completion_tokens: 100,
-      },
-      supported_parameters: [],
-      isFree: false,
-    },
-    {
-      id: "demo/free",
-      name: "Explicit free",
-      created: 2,
-      description: "Free",
-      context_length: 1000,
-      architecture: {
-        input_modalities: ["text"],
-        output_modalities: ["text"],
-        tokenizer: "Other",
-      },
-      pricing: { prompt: "0", completion: "0" },
-      top_provider: {
-        is_moderated: false,
-        context_length: 1000,
-        max_completion_tokens: 100,
-      },
-      supported_parameters: [],
-      isFree: true,
-    },
-  ] satisfies Parameters<typeof filterFreeModels>[0]);
-
-  assert.deepEqual(
-    filtered.map((model) => model.id),
-    ["demo/free"],
-  );
-});
+import { convertToPiModels } from "../src/provider/models";
 
 test("convertToPiModels drops image-only models and maps capabilities/pricing", () => {
   const converted = convertToPiModels([


### PR DESCRIPTION
## Summary

`getCachedPiModels()` was filtering the model list to `isFree === true`
models only.

Authenticated users have access to the full Kilo Code model catalogue,
so the filter was hiding paid models they are entitled to use. This
removes the filter and exposes every model returned by the API.

The `filterFreeModels` export is kept as-is since it is tested and may
be useful to callers who explicitly want only free models.