### PR TITLE
fix(pi-cursor-agent): treat no-such-file errors separately

### DIFF
--- a/pi-cursor-agent/src/bridge/cursor-to-pi/executors/read.ts
+++ b/pi-cursor-agent/src/bridge/cursor-to-pi/executors/read.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../__generated__/agent/v1/read_exec_pb";
 import {
   ReadError,
+  ReadFileNotFound,
   ReadRejected,
   ReadResult as ReadResultClass,
   ReadSuccess,
@@ -18,12 +19,29 @@ import type { PiToolContext } from "../local-resource-provider/types";
 import { decodeToolCallId } from "../local-resource-provider/types";
 import { requestToolExecution } from "../tool-bridge";
 
+/** True when Pi's read tool failed because the path is missing (maps to Cursor ReadFileNotFound). */
+function isMissingFileReadError(message: string): boolean {
+  const m = message.trim();
+  if (!m) return false;
+  if (/\bENOENT\b/.test(m)) return true;
+  if (/no such file or directory/i.test(m)) return true;
+  return false;
+}
+
 export function buildReadResultFromToolResult(
   path: string,
   result: ToolResultMessage,
 ): ReadResult {
   const text = toolResultToText(result);
   if (result.isError) {
+    if (isMissingFileReadError(text)) {
+      return new ReadResultClass({
+        result: {
+          case: "fileNotFound",
+          value: new ReadFileNotFound({ path }),
+        },
+      });
+    }
     return new ReadResultClass({
       result: {
         case: "error",

--- a/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
+++ b/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { buildReadResultFromToolResult } from "../../../src/bridge/cursor-to-pi/executors/read.js";
+
+function errResult(text: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "t1",
+    content: [{ type: "text", text }],
+    isError: true,
+  };
+}
+
+test("ENOENT maps to ReadResult fileNotFound", () => {
+  const r = buildReadResultFromToolResult(
+    "missing.txt",
+    errResult(
+      "ENOENT: no such file or directory, access '/tmp/missing.txt'",
+    ),
+  );
+  assert.equal(r.result.case, "fileNotFound");
+  if (r.result.case === "fileNotFound") {
+    assert.equal(r.result.value.path, "missing.txt");
+  }
+});
+
+test("generic read error stays ReadError", () => {
+  const r = buildReadResultFromToolResult(
+    "x.txt",
+    errResult("Something else went wrong"),
+  );
+  assert.equal(r.result.case, "error");
+  if (r.result.case === "error") {
+    assert.match(r.result.value.error, /Something else/);
+  }
+});


### PR DESCRIPTION
The cursor agent always couples a write call with a prequel read call. The API expects ENOENT from the read call to be marked appropriately, otherwise it wont attempt the write call and fail with a generic error, causing models to resort to bash commands when writing (new) files.