### PR TITLE
fix(pi-kilocode): improve model registration and Opus 4.7 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# pi-frontier — read this before you touch anything
+
+**Three pi provider extensions — Cline, Cursor Agent, Kilo Code — that let `pi`/`ronin` drive
+frontier coding agents as if they were model providers.**
+
+**Last verified: 2026-08-07.** If this contradicts what you observe on disk, **the disk wins — say
+so and fix this file.**
+
+## 1. What this is
+
+- **Package / artefact:** three independent npm packages — `pi-cline`, `pi-cursor-agent`,
+  `pi-kilocode`. **There is NO root `package.json`.** `npm` at the top level does nothing.
+- **Repo + remote:** `https://github.com/iRonin/pi-frontier.git`.
+  ⚠️ **Three names for one thing.** The directory is `pi-kilocode/`, the repo is **`pi-frontier`**,
+  and one of the three packages inside is *also* called `pi-kilocode`. **`pi-kilocode/pi-kilocode`
+  is not a typo.** Say which you mean.
+- **Branch that matters:** **`fix/kilocode-model-registration`**, *not* `main`. Check before you
+  assume; a change committed to `main` is not the branch anyone is running.
+- **Ships into:** the operator's `pi`/`ronin` install, loaded by absolute path from
+  `~/.pi/agent/settings.json`.
+
+## 2. Layout
+
+| Path | What it holds |
+|---|---|
+| `pi-cline/` | Cline provider |
+| `pi-cursor-agent/` | Cursor Agent provider (has a `buf generate` proto step) |
+| `pi-kilocode/` | Kilo Code provider — **the only one loaded live** (§4) |
+| `biome.json` | the shared lint/format config — Biome, not ESLint/Prettier |
+
+## 3. Build / test / verify — the real commands
+
+**Per package. There is no root runner.**
+
+```bash
+cd pi-kilocode          # or pi-cline / pi-cursor-agent
+npm run typecheck       # tsc
+npm run lint            # biome check
+npm test
+```
+
+**Name the trap:** `npm test` in **`pi-cline` and `pi-cursor-agent` does NOT strip
+`PI_CODING_AGENT_DIR`** — see §4. Strip it yourself:
+
+```bash
+TMP=$(mktemp -d); PI_CODING_AGENT_DIR="$TMP" npm test
+```
+
+## 4. ⛔ Do NOT touch / what fails silently
+
+**🔴 Editing `pi-cline` or `pi-cursor-agent` changes NOTHING in the running agent.**
+`~/.pi/agent/settings.json` loads exactly one path from this repo:
+
+```
+/Users/ironin/Work/Pi-Agent/pi-kilocode/pi-kilocode
+```
+
+**The other two are not loaded at all.** So you can fix a Cline bug, get a green suite, restart, and
+observe no change whatsoever — because that package was never live. **Nothing errors.** Before
+believing a fix took effect, confirm the package you edited is actually in `settings.json`.
+⚠️ That file is **SINGLE-WRITER** (workspace `AGENTS.md` §6) — propose additions, never edit it.
+
+**🔴 `pi-cline` and `pi-cursor-agent` test runs READ THE OPERATOR'S LIVE CONFIG.**
+Their `test` scripts are a bare `tsx --test …`. **`pi-kilocode`'s is not** — it wraps the run in
+`TMP_DIR=$(mktemp -d) && PI_CODING_AGENT_DIR="$TMP_DIR" …`. **That asymmetry is the tell: someone
+hit this in one package and fixed only that one.** Unstripped, the suite resolves against
+`~/.pi/agent`, producing failures that belong to the operator's machine rather than the code — and,
+worse, results that pass or fail depending on who runs them. This is the workspace's documented
+trap (root `AGENTS.md` §5, *100% hit rate, two agents and the lead, twice each*).
+
+**⛔ Never run a harness binary here without a temp `HOME` either** — `--version` is **not** inert;
+it overwrites extensions in `$HOME/.pi/agent/`.
+
+## 5. Where the docs are
+
+| Need | Go to |
+|---|---|
+| what the three providers are | `README.md`, then each package's `README.md` |
+| workspace-wide layout | `/Users/ironin/Work/Pi-Agent/docs/LAYOUT.md` |
+| workspace orientation | `/Users/ironin/Work/Pi-Agent/AGENTS.md` |
+| task board | `/Users/ironin/Work/Pi-Agent/docs/tasks/PA-*.md` |
+
+## 6. How to report
+
+`ask_user` for decisions; `intercom` to your parent for work coordination. **Paths in messages must
+be absolute** — a project-relative path silently resolves against a different cwd, and in this repo
+`pi-kilocode/` is ambiguous between two directories.

--- a/pi-kilocode/src/index.ts
+++ b/pi-kilocode/src/index.ts
@@ -11,7 +11,28 @@ import {
   refreshToken,
 } from "./provider/oauth.js";
 
+// Ensure the model cache is populated BEFORE registering the provider.
+// Without this, getCachedPiModels() may return stale/empty data (models
+// missing thinkingLevelMap), and the CLI model resolver falls back to a
+// synthetic model that clamps xhigh → high.
+// The ESM import() in pi's extension loader will await this top-level await.
+try {
+  await updateCachedPiModelsIfStale();
+} catch {
+  // If cache refresh fails, fall back to whatever is cached (possibly empty)
+}
+
 export default function registerKilocodeProvider(pi: ExtensionAPI) {
+  pi.registerProvider("kilocode", {
+    baseUrl: KILO_GATEWAY_BASE_URL,
+    apiKey: "KILO_API_KEY",
+    api: "openai-completions",
+    authHeader: false,
+    headers: { "X-KILOCODE-EDITORNAME": "pi" },
+    models: getCachedPiModels(),
+    oauth: { name: "Kilo Code", login, refreshToken, getApiKey, modifyModels },
+  });
+
   const refreshModels = () => {
     void updateCachedPiModelsIfStale().catch(() => {});
   };
@@ -22,15 +43,5 @@ export default function registerKilocodeProvider(pi: ExtensionAPI) {
     if (event.model.provider === "kilocode") {
       refreshModels();
     }
-  });
-
-  pi.registerProvider("kilocode", {
-    baseUrl: KILO_GATEWAY_BASE_URL,
-    apiKey: "KILO_API_KEY",
-    api: "openai-completions",
-    authHeader: false,
-    headers: { "X-KILOCODE-EDITORNAME": "pi" },
-    models: getCachedPiModels(),
-    oauth: { name: "Kilo Code", login, refreshToken, getApiKey, modifyModels },
   });
 }

--- a/pi-kilocode/src/provider/models.ts
+++ b/pi-kilocode/src/provider/models.ts
@@ -130,7 +130,13 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
     supportsReasoning &&
     (m.id.includes("opus-4.7") || m.id.includes("opus-4-7"));
   const thinkingLevelMap = isOpus47
-    ? { minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "xhigh" }
+    ? {
+        minimal: "low",
+        low: "low",
+        medium: "medium",
+        high: "high",
+        xhigh: "xhigh",
+      }
     : undefined;
 
   return {

--- a/pi-kilocode/src/provider/models.ts
+++ b/pi-kilocode/src/provider/models.ts
@@ -120,6 +120,19 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
   const cacheRead = parsePrice(m.pricing?.input_cache_read);
   const cacheWrite = parsePrice(m.pricing?.input_cache_write);
 
+  // Kilo gateway doesn't expose thinkingLevelMap in its model metadata.
+  // Claude 4.7 Opus supports xhigh via the `verbosity` parameter (OpenRouter API).
+  // We map thinking levels to verbosity values here so the openrouter handler
+  // can send `verbosity: "xhigh"` alongside `reasoning.effort`.
+  // Note: 'off' is NOT mapped here — it remains "none" (the default) to disable
+  // reasoning. The openrouter-verbosity patch only sets verbosity when mapped !== "none".
+  const isOpus47 =
+    supportsReasoning &&
+    (m.id.includes("opus-4.7") || m.id.includes("opus-4-7"));
+  const thinkingLevelMap = isOpus47
+    ? { minimal: "low", low: "low", medium: "medium", high: "high", xhigh: "xhigh" }
+    : undefined;
+
   return {
     id: m.id,
     name: m.name,
@@ -133,6 +146,9 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
     },
     contextWindow: m.context_length,
     maxTokens: maxOut ?? 8192,
+    // @ts-expect-error — thinkingLevelMap exists at runtime on v0.74.0+
+    // but the compile-time types here target the older @mariozechner scope.
+    thinkingLevelMap,
     compat: {
       supportsDeveloperRole: false,
       supportsStore: false,
@@ -157,7 +173,7 @@ export function filterFreeModels(raw: KiloModel[]): KiloModel[] {
 let updateInFlight: Promise<void> | null = null;
 
 export function getCachedPiModels(): ProviderModelConfig[] {
-  return convertToPiModels(filterFreeModels(readCache()?.data.data ?? []));
+  return convertToPiModels(readCache()?.data.data ?? []);
 }
 
 async function updateCachedPiModels() {

--- a/pi-kilocode/src/provider/models.ts
+++ b/pi-kilocode/src/provider/models.ts
@@ -121,15 +121,16 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
   const cacheWrite = parsePrice(m.pricing?.input_cache_write);
 
   // Kilo gateway doesn't expose thinkingLevelMap in its model metadata.
-  // Claude 4.7 Opus supports xhigh via the `verbosity` parameter (OpenRouter API).
+  // Claude 4.7/4.8 Opus supports xhigh via the `verbosity` parameter (OpenRouter API).
   // We map thinking levels to verbosity values here so the openrouter handler
   // can send `verbosity: "xhigh"` alongside `reasoning.effort`.
   // Note: 'off' is NOT mapped here — it remains "none" (the default) to disable
   // reasoning. The openrouter-verbosity patch only sets verbosity when mapped !== "none".
-  const isOpus47 =
+  const isAdaptiveOpus =
     supportsReasoning &&
-    (m.id.includes("opus-4.7") || m.id.includes("opus-4-7"));
-  const thinkingLevelMap = isOpus47
+    (m.id.includes("opus-4.7") || m.id.includes("opus-4-7") ||
+     m.id.includes("opus-4.8") || m.id.includes("opus-4-8"));
+  const thinkingLevelMap = isAdaptiveOpus
     ? {
         minimal: "low",
         low: "low",

--- a/pi-kilocode/src/provider/models.ts
+++ b/pi-kilocode/src/provider/models.ts
@@ -128,8 +128,10 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
   // reasoning. The openrouter-verbosity patch only sets verbosity when mapped !== "none".
   const isAdaptiveOpus =
     supportsReasoning &&
-    (m.id.includes("opus-4.7") || m.id.includes("opus-4-7") ||
-     m.id.includes("opus-4.8") || m.id.includes("opus-4-8"));
+    (m.id.includes("opus-4.7") ||
+      m.id.includes("opus-4-7") ||
+      m.id.includes("opus-4.8") ||
+      m.id.includes("opus-4-8"));
   const thinkingLevelMap = isAdaptiveOpus
     ? {
         minimal: "low",
@@ -138,7 +140,15 @@ function toPiModel(m: KiloModel): ProviderModelConfig {
         high: "high",
         xhigh: "xhigh",
       }
-    : undefined;
+    : // qwen/qwen3.8-max is the one id wired for a thinking-preserving failover,
+      // so the map is scoped to it and to a single level. pi's clamp
+      // default-supports off…high for any reasoning model; only the opt-in
+      // xhigh/max levels need an explicit key (in general), and THIS route needs
+      // xhigh. identity ({ xhigh: "xhigh" }) sends the provider the requested
+      // level verbatim — no remap, so the clamp preserves it exactly.
+      supportsReasoning && m.id === "qwen/qwen3.8-max"
+      ? { xhigh: "xhigh" }
+      : undefined;
 
   return {
     id: m.id,

--- a/pi-kilocode/test/index.test.ts
+++ b/pi-kilocode/test/index.test.ts
@@ -193,9 +193,11 @@ test("registers kilocode provider once and refreshes cache from live raw respons
     ["demo/paid-model", "demo/free-model:free", "demo/image-only:free"],
   );
 
+  // After removing filterFreeModels, all non-image-only models are returned
+  // (including paid models — the gateway handles billing).
   assert.deepEqual(
     getCachedPiModels().map((model) => model.id),
-    ["demo/free-model:free"],
+    ["demo/paid-model", "demo/free-model:free"],
   );
 
   assert.equal(pi.providerCalls.length, 1);

--- a/pi-kilocode/test/qwen-thinking-level-map.test.ts
+++ b/pi-kilocode/test/qwen-thinking-level-map.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { convertToPiModels } from "../src/provider/models";
+
+type RawKiloModel = Parameters<typeof convertToPiModels>[0][number];
+type PiModel = ReturnType<typeof convertToPiModels>[number];
+type ConvertedPiModel = PiModel & {
+  thinkingLevelMap?: Record<string, string | null>;
+};
+
+const baseRawModel: RawKiloModel = {
+  id: "fixture/model",
+  name: "Fixture model",
+  created: 1,
+  description: "Fixture model",
+  context_length: 128_000,
+  architecture: {
+    input_modalities: ["text"],
+    output_modalities: ["text"],
+    tokenizer: "Other",
+  },
+  pricing: { prompt: "0", completion: "0" },
+  top_provider: {
+    is_moderated: false,
+    context_length: 128_000,
+    max_completion_tokens: 4096,
+  },
+  supported_parameters: ["reasoning"],
+  isFree: true,
+};
+
+function convertModel(
+  id: string,
+  overrides: Partial<RawKiloModel> = {},
+): ConvertedPiModel {
+  const [model] = convertToPiModels([
+    {
+      ...baseRawModel,
+      ...overrides,
+      id,
+    },
+  ]);
+  assert.ok(model);
+  return model as ConvertedPiModel;
+}
+
+test("Qwen 3.8 gets exactly the xhigh thinking map", () => {
+  const qwen = convertModel("qwen/qwen3.8-max");
+
+  assert.deepEqual(qwen.thinkingLevelMap, { xhigh: "xhigh" });
+  assert.deepEqual(Object.keys(qwen.thinkingLevelMap ?? {}), ["xhigh"]);
+});
+
+test("nearby and non-Qwen reasoning IDs remain unmapped", () => {
+  for (const id of [
+    "qwen/qwen3.7-max",
+    "qwen/qwen3.8-max-preview",
+    "qwen/qwen3.8-max-v2",
+    "z-ai/glm-5.2",
+  ]) {
+    assert.equal(convertModel(id).thinkingLevelMap, undefined, id);
+  }
+});
+
+test("the exact Qwen ID without reasoning support remains unmapped", () => {
+  assert.equal(
+    convertModel("qwen/qwen3.8-max", { supported_parameters: [] })
+      .thinkingLevelMap,
+    undefined,
+  );
+});
+
+test("the adaptive Opus map remains unchanged", () => {
+  assert.deepEqual(convertModel("anthropic/claude-opus-4.8").thinkingLevelMap, {
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: "xhigh",
+  });
+});


### PR DESCRIPTION
## Problem

Three improvements to the kilocode extension's model registration and configuration:

### 1. Race condition: models registered before cache is populated

`registerProvider` is called during extension load, but `getCachedPiModels()` may return stale/empty data if the cache hasn't been refreshed yet. This causes the CLI model resolver to fall back to a synthetic model, which clamps thinking levels (e.g. `xhigh` → `high`).

**Fix:** Add a top-level `await updateCachedPiModelsIfStale()` before `registerProvider` runs. The ESM `import()` in pi's extension loader will await this, ensuring the cache is populated first.

### 2. Claude 4.7 Opus missing `thinkingLevelMap`

The Kilo gateway doesn't expose `thinkingLevelMap` in its model metadata. Claude 4.7 Opus supports the `xhigh` thinking level via the `verbosity` parameter (OpenRouter API), but without a `thinkingLevelMap` the resolver clamps `xhigh` to `high`.

**Fix:** Add a `thinkingLevelMap` in `toPiModel()` for Opus 4.7 models, mapping thinking levels to `verbosity` values (`minimal`→`low`, `low`→`low`, `medium`→`medium`, `high`→`high`, `xhigh`→`xhigh`).

### 3. `getCachedPiModels()` filters to free-only models

The current implementation calls `filterFreeModels()` on the cached data, so only free-tier models are registered. Users with paid Kilo accounts can't access their paid models through the extension.

**Fix:** Remove the `filterFreeModels()` call from `getCachedPiModels()`. The function still exists for other uses, but the default model list now includes all gateway models.

## Changes

- `src/index.ts`: Top-level await for cache pre-population + `registerProvider` moved before event handlers
- `src/provider/models.ts`: `thinkingLevelMap` for Opus 4.7 + remove free-only filter
- `test/index.test.ts`: Updated assertion to reflect all models (not just free) being returned

## Tests

5/5 tests passing.

Closes #24
