### PR TITLE
Address legacy warning

### DIFF
--- a/pi-cursor-agent/src/index.ts
+++ b/pi-cursor-agent/src/index.ts
@@ -145,7 +145,7 @@ export default (pi: ExtensionAPI) => {
 
   pi.registerProvider("cursor-agent", {
     baseUrl: CURSOR_API_URL,
-    apiKey: "CURSOR_ACCESS_TOKEN",
+    apiKey: "$CURSOR_ACCESS_TOKEN",
     api: "cursor-agent" as unknown as Api,
     streamSimple: (model, context, options) =>
       streamCursorAgent(pi, getCtx, state, model, context, options),


### PR DESCRIPTION
Resolves the following warning:

>Deprecation warning: registerProvider("cursor-agent") apiKey value "CURSOR_ACCESS_TOKEN" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$CURSOR_ACCESS_TOKEN" instead.