### PR TITLE
fix(pi-cursor-agent): keep real prompt when trailing custom user notes exist

### DIFF
--- a/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
+++ b/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
@@ -55,6 +55,33 @@ function extractUserMessageText(msg: Message): string {
     .trim();
 }
 
+/**
+ * Resolve the current-turn user text for Cursor's userMessageAction.
+ *
+ * Pi extensions (e.g. pi-subagents ambient roster) inject custom messages after
+ * the real prompt. convertToLlm maps those to consecutive trailing `user`
+ * messages. Taking only messages.at(-1) would drop the real prompt, so join
+ * the entire trailing consecutive-user block instead.
+ */
+function resolveCurrentUserText(messages: Message[]): string {
+  const trailing: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || msg.role !== "user") break;
+    const text = extractUserMessageText(msg);
+    if (text) trailing.unshift(text);
+  }
+  return trailing.join("\n\n");
+}
+
+/** True when this user message is part of the open turn (no non-user after it). */
+function isInCurrentUserTurn(messages: Message[], index: number): boolean {
+  for (let j = index + 1; j < messages.length; j++) {
+    if (messages[j]?.role !== "user") return false;
+  }
+  return true;
+}
+
 /** Format content blocks (thinking, text, toolCall) into a single string. */
 function formatContentBlocks(blocks: unknown[]): string {
   const parts: string[] = [];
@@ -122,14 +149,9 @@ function buildConversationTurns(
       continue;
     }
 
-    let isLastUserMessage = true;
-    for (let j = i + 1; j < messages.length; j++) {
-      if (messages[j]?.role === "user") {
-        isLastUserMessage = false;
-        break;
-      }
-    }
-    if (isLastUserMessage) break;
+    // Trailing consecutive user messages (prompt + converted custom notes)
+    // belong to the current Cursor action, not seeded history turns.
+    if (isInCurrentUserTurn(messages, i)) break;
 
     const userText = extractUserMessageText(msg);
     if (!userText) {
@@ -258,8 +280,7 @@ export function buildRunRequest(
   const systemPromptId = getBlobId(systemPromptBytes);
   void params.blobStore.setBlob(null, systemPromptId, systemPromptBytes);
 
-  const lastMessage = params.context.messages.at(-1);
-  const userText = lastMessage ? extractUserMessageText(lastMessage) : "";
+  const userText = resolveCurrentUserText(params.context.messages);
   if (!userText) {
     throw new Error("Cannot send empty user message to Cursor API");
   }

--- a/pi-cursor-agent/test/bridge/pi-to-cursor/request-builder.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-to-cursor/request-builder.test.ts
@@ -199,3 +199,59 @@ test("reconstruction works without state", () => {
 
   assert.equal(buildRunRequest(params).conversationState.turns.length, 1);
 });
+
+function getActionUserText(result: ReturnType<typeof buildRunRequest>): string {
+  assert.equal(result.initialRequest.message.case, "runRequest");
+  const runRequest = result.initialRequest.message.value;
+  assert.equal(runRequest.action?.action.case, "userMessageAction");
+  const userMessage = runRequest.action?.action.value.userMessage;
+  assert.ok(userMessage);
+  return userMessage.text;
+}
+
+test("joins trailing consecutive user messages for the Cursor action", () => {
+  const roster =
+    "<system-reminder>\nYou can launch separate helper agents\n<subagent-roster>\n- `scout`: Fast recon\n</subagent-roster>\n</system-reminder>";
+  const { params } = createParams({
+    messages: [
+      { role: "user", content: "push to github", timestamp: 1 },
+      { role: "user", content: roster, timestamp: 2 },
+    ],
+  });
+
+  const result = buildRunRequest(params);
+  assert.equal(getActionUserText(result), `push to github\n\n${roster}`);
+  // Prompt + roster are the open turn; do not seed a history turn for the prompt alone.
+  assert.equal(result.conversationState.turns.length, 0);
+});
+
+test("keeps prior completed turns when trailing custom user notes follow a new prompt", () => {
+  const roster = "<system-reminder>\nsubagent roster\n</system-reminder>";
+  const { params } = createParams({
+    messages: [
+      { role: "user", content: "Remember BANANA42.", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+        timestamp: 2,
+        ...ASSISTANT_DEFAULTS,
+      },
+      { role: "user", content: "What code word?", timestamp: 3 },
+      { role: "user", content: roster, timestamp: 4 },
+    ],
+  });
+
+  const result = buildRunRequest(params);
+  assert.equal(getActionUserText(result), `What code word?\n\n${roster}`);
+  assert.equal(result.conversationState.turns.length, 1);
+});
+
+test("single trailing user message still becomes the action unchanged", () => {
+  const { params } = createParams({
+    messages: [{ role: "user", content: "hello", timestamp: 1 }],
+  });
+
+  const result = buildRunRequest(params);
+  assert.equal(getActionUserText(result), "hello");
+  assert.equal(result.conversationState.turns.length, 0);
+});


### PR DESCRIPTION
## Summary
- Join trailing consecutive `user` messages when building the Cursor `userMessageAction`, so Pi custom notes converted by `convertToLlm` (e.g. `pi-subagents` ambient roster) no longer replace the real first-turn prompt.
- Treat that trailing user block as the open turn in history seeding, avoiding a prompt-only history turn with no assistant reply.
- Adds regression coverage for first-turn prompt+roster and follow-up turns with prior history.

Fixes #27

## Test plan
- [x] `npm test` in `pi-cursor-agent` (37 passing)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: new Pi session with `cursor-agent/*` + `pi-subagents`, first prompt like `push to github` should be answered (roster still visible as context)