### PR TITLE
fix(pi-cursor-agent): stabilize steering and forked subagents

### DIFF
--- a/pi-cursor-agent/src/bridge/cursor-to-pi/executors/read.ts
+++ b/pi-cursor-agent/src/bridge/cursor-to-pi/executors/read.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../__generated__/agent/v1/read_exec_pb";
 import {
   ReadError,
+  ReadFileNotFound,
   ReadRejected,
   ReadResult as ReadResultClass,
   ReadSuccess,
@@ -18,12 +19,29 @@ import type { PiToolContext } from "../local-resource-provider/types";
 import { decodeToolCallId } from "../local-resource-provider/types";
 import { requestToolExecution } from "../tool-bridge";
 
+/** True when Pi's read tool failed because the path is missing (maps to Cursor ReadFileNotFound). */
+function isMissingFileReadError(message: string): boolean {
+  const m = message.trim();
+  if (!m) return false;
+  if (/\bENOENT\b/.test(m)) return true;
+  if (/no such file or directory/i.test(m)) return true;
+  return false;
+}
+
 export function buildReadResultFromToolResult(
   path: string,
   result: ToolResultMessage,
 ): ReadResult {
   const text = toolResultToText(result);
   if (result.isError) {
+    if (isMissingFileReadError(text)) {
+      return new ReadResultClass({
+        result: {
+          case: "fileNotFound",
+          value: new ReadFileNotFound({ path }),
+        },
+      });
+    }
     return new ReadResultClass({
       result: {
         case: "error",

--- a/pi-cursor-agent/src/bridge/pi-context/parser.ts
+++ b/pi-cursor-agent/src/bridge/pi-context/parser.ts
@@ -86,12 +86,37 @@ const PRESERVED_PATTERNS = [
   /^Current working directory: .+$/m,
 ];
 
-function buildCleanedPrompt(original: string, hasExtracted: boolean): string {
-  const lines = PRESERVED_PATTERNS.map((re) => original.match(re)?.[0]).filter(
-    (s): s is string => s != null,
-  );
+// Pi appends generated tool/context/skill metadata after the caller-provided
+// system instructions. Cursor receives those sections through native tools and
+// RequestContext.rules, but the instruction prefix must remain in the root
+// prompt — especially for agents using `system-prompt: replace`.
+const GENERATED_SECTION_MARKERS = [
+  "\nAvailable tools:",
+  "\nPi documentation",
+  `\n${CONTEXT_HEADING}`,
+  `\n${SKILLS_OPEN}`,
+  "\nCurrent date:",
+  "\nCurrent working directory:",
+];
 
-  return lines.length === 0 && !hasExtracted ? original : lines.join("\n");
+function extractInstructionPrefix(prompt: string): string {
+  let end = prompt.length;
+  for (const marker of GENERATED_SECTION_MARKERS) {
+    const index = prompt.indexOf(marker);
+    if (index !== -1 && index < end) end = index;
+  }
+  return prompt.slice(0, end).trim();
+}
+
+function buildCleanedPrompt(original: string, hasExtracted: boolean): string {
+  const instructionPrefix = extractInstructionPrefix(original);
+  const preserved = [
+    instructionPrefix,
+    ...PRESERVED_PATTERNS.map((re) => original.match(re)?.[0]),
+  ].filter((s): s is string => Boolean(s));
+
+  if (preserved.length === 0 && !hasExtracted) return original;
+  return [...new Set(preserved)].join("\n\n");
 }
 
 export function parsePiSystemPrompt(systemPrompt: string): ParsedPiContext {

--- a/pi-cursor-agent/src/bridge/pi-context/rules-builder.ts
+++ b/pi-cursor-agent/src/bridge/pi-context/rules-builder.ts
@@ -67,7 +67,14 @@ async function agentFetchedRule(skill: PiSkillRef): Promise<CursorRule> {
 export async function buildCursorRules(
   parsed: ParsedPiContext,
 ): Promise<CursorRule[]> {
+  // Cursor appends its own provider system prompt after the root conversation
+  // message, so models may ignore Pi's earlier system message. Mirror the
+  // cleaned Pi instructions into an always-applied global rule as well.
+  const systemPrompt = parsed.cleanedPrompt.trim();
+  const systemRules = systemPrompt
+    ? [globalRule("/__pi__/system-prompt.md", systemPrompt)]
+    : [];
   const globals = parsed.contextFiles.map((f) => globalRule(f.path, f.content));
   const skills = await Promise.all(parsed.skills.map(agentFetchedRule));
-  return [...globals, ...skills];
+  return [...systemRules, ...globals, ...skills];
 }

--- a/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
+++ b/pi-cursor-agent/src/bridge/pi-to-cursor/request-builder.ts
@@ -55,6 +55,52 @@ function extractUserMessageText(msg: Message): string {
     .trim();
 }
 
+function resolveCurrentUserTexts(messages: Message[]): string[] {
+  const trailing: string[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message || message.role !== "user") break;
+    const text = extractUserMessageText(message);
+    if (text) trailing.unshift(text);
+  }
+  return trailing;
+}
+
+function isInCurrentUserTurn(messages: Message[], index: number): boolean {
+  for (let i = index + 1; i < messages.length; i++) {
+    if (messages[i]?.role !== "user") return false;
+  }
+  return true;
+}
+
+function createUserMessageAction(text: string): ConversationAction {
+  const userMessage = new UserMessage({
+    text,
+    messageId: crypto.randomUUID(),
+  });
+
+  return new ConversationAction({
+    action: {
+      case: "userMessageAction",
+      value: new UserMessageAction({ userMessage }),
+    },
+  });
+}
+
+/**
+ * Build the user actions added by Pi between Cursor tool boundaries.
+ *
+ * Without steering, a continuation context ends in a tool result. Trailing
+ * user messages therefore represent new input that must be forwarded into the
+ * still-running Cursor conversation. Pi can deliver more than one message at
+ * once, so preserve the original order of the entire trailing user block.
+ */
+export function buildContinuationActions(
+  context: Context,
+): ConversationAction[] {
+  return resolveCurrentUserTexts(context.messages).map(createUserMessageAction);
+}
+
 /** Format content blocks (thinking, text, toolCall) into a single string. */
 function formatContentBlocks(blocks: unknown[]): string {
   const parts: string[] = [];
@@ -122,14 +168,7 @@ function buildConversationTurns(
       continue;
     }
 
-    let isLastUserMessage = true;
-    for (let j = i + 1; j < messages.length; j++) {
-      if (messages[j]?.role === "user") {
-        isLastUserMessage = false;
-        break;
-      }
-    }
-    if (isLastUserMessage) break;
+    if (isInCurrentUserTurn(messages, i)) break;
 
     const userText = extractUserMessageText(msg);
     if (!userText) {
@@ -258,23 +297,14 @@ export function buildRunRequest(
   const systemPromptId = getBlobId(systemPromptBytes);
   void params.blobStore.setBlob(null, systemPromptId, systemPromptBytes);
 
-  const lastMessage = params.context.messages.at(-1);
-  const userText = lastMessage ? extractUserMessageText(lastMessage) : "";
+  const userText = resolveCurrentUserTexts(params.context.messages).join(
+    "\n\n",
+  );
   if (!userText) {
     throw new Error("Cannot send empty user message to Cursor API");
   }
 
-  const userMessage = new UserMessage({
-    text: userText,
-    messageId: crypto.randomUUID(),
-  });
-
-  const action = new ConversationAction({
-    action: {
-      case: "userMessageAction",
-      value: new UserMessageAction({ userMessage }),
-    },
-  });
+  const action = createUserMessageAction(userText);
 
   const cached = params.conversationState;
   const turns = buildConversationTurns(

--- a/pi-cursor-agent/src/index.ts
+++ b/pi-cursor-agent/src/index.ts
@@ -132,11 +132,6 @@ export default (pi: ExtensionAPI) => {
     updateCachedModelsFromContextInBackground(ctx);
   });
 
-  pi.on("session_switch", async (_, ctx) => {
-    await refreshBranchState(ctx);
-    updateCachedModelsFromContextInBackground(ctx);
-  });
-
   pi.on("session_tree", async (_, ctx) => {
     await refreshBranchState(ctx);
   });

--- a/pi-cursor-agent/src/index.ts
+++ b/pi-cursor-agent/src/index.ts
@@ -16,7 +16,10 @@ import {
   CURSOR_CLIENT_VERSION,
   CURSOR_WEBSITE_URL,
 } from "./lib/env";
-import { restoreAgentStoreFromBranch } from "./provider/agent-store";
+import {
+  isExternallyManagedSubagentSession,
+  restoreAgentStoreFromBranch,
+} from "./provider/agent-store";
 import {
   getCachedPiModels,
   updateCachedPiModelsIfStale,
@@ -91,12 +94,19 @@ export default (pi: ExtensionAPI) => {
   const refreshBranchState = async (ctx: ExtensionContext) => {
     lastCtx = ctx;
     const sessionId = ctx.sessionManager.getSessionId();
+    const sessionHeader = ctx.sessionManager.getHeader();
     await cleanupPreviousSession(sessionId);
     state.resetFromContext(ctx);
     try {
       await restoreAgentStoreFromBranch(
         sessionId,
         ctx.sessionManager.getBranch(),
+        ctx.sessionManager.getEntries(),
+        sessionHeader?.timestamp,
+        isExternallyManagedSubagentSession(
+          ctx.sessionManager.getSessionFile(),
+          process.env["PI_SUBAGENT_SESSION"],
+        ),
       );
     } catch {}
     retainOnlyActiveSessionMemory(sessionId);

--- a/pi-cursor-agent/src/provider/agent-store.ts
+++ b/pi-cursor-agent/src/provider/agent-store.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { SessionEntry } from "@mariozechner/pi-coding-agent";
 import { ConversationStateStructure } from "../__generated__/agent/v1/agent_pb";
 import {
@@ -10,6 +11,19 @@ import { type AgentStore, fromHex, toHex } from "../vendor/agent-kv";
 import { PI_CURSOR_AGENT_CACHE_DIR } from "./env";
 
 export const CURSOR_STATE_ENTRY_TYPE = "pi-cursor-agent:state";
+
+export const isExternallyManagedSubagentSession = (
+  activeSessionFile: string | undefined,
+  managedSessionFile: string | undefined,
+): boolean =>
+  Boolean(
+    activeSessionFile &&
+      managedSessionFile &&
+      resolve(activeSessionFile) === resolve(managedSessionFile),
+  );
+
+const SUBAGENT_BOUNDARY_ENTRY_TYPE = "subagent_boundary";
+const SUBAGENT_LAUNCH_METADATA_ENTRY_TYPE = "pi-subagents_launch_metadata";
 
 interface AgentStoreSnapshot {
   version: 1;
@@ -31,16 +45,71 @@ const isAgentStoreSnapshot = (value: unknown): value is AgentStoreSnapshot => {
   );
 };
 
-const findSnapshot = (entries: SessionEntry[]): AgentStoreSnapshot | null => {
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const e = entries[i];
-    if (!e || e.type !== "custom" || e.customType !== CURSOR_STATE_ENTRY_TYPE) {
+const findProvenanceBoundaryIndex = (
+  sessionEntries: SessionEntry[],
+  sessionStartedAt?: string,
+): number => {
+  const startedAt = sessionStartedAt
+    ? Date.parse(sessionStartedAt)
+    : Number.NaN;
+  if (Number.isFinite(startedAt)) {
+    const launchIndex = sessionEntries.findIndex(
+      (entry) =>
+        entry.type === "custom" &&
+        entry.customType === SUBAGENT_LAUNCH_METADATA_ENTRY_TYPE &&
+        Date.parse(entry.timestamp) >= startedAt,
+    );
+    if (launchIndex >= 0) {
+      return launchIndex;
+    }
+  }
+
+  for (let i = sessionEntries.length - 1; i >= 0; i--) {
+    const entry = sessionEntries[i];
+    if (
+      entry?.type === "custom_message" &&
+      entry.customType === SUBAGENT_BOUNDARY_ENTRY_TYPE
+    ) {
+      return i;
+    }
+  }
+  return -1;
+};
+
+const findSnapshot = (
+  branchEntries: SessionEntry[],
+  sessionEntries: SessionEntry[],
+  sessionStartedAt: string | undefined,
+  isSubagentSession: boolean,
+): AgentStoreSnapshot | null => {
+  const boundaryIndex = findProvenanceBoundaryIndex(
+    sessionEntries,
+    sessionStartedAt,
+  );
+  if (isSubagentSession && boundaryIndex < 0) {
+    return null;
+  }
+
+  for (let i = branchEntries.length - 1; i >= 0; i--) {
+    const entry = branchEntries[i];
+    if (
+      entry?.type !== "custom" ||
+      entry.customType !== CURSOR_STATE_ENTRY_TYPE ||
+      !isAgentStoreSnapshot(entry.data)
+    ) {
       continue;
     }
 
-    if (isAgentStoreSnapshot(e.data)) {
-      return e.data;
+    if (boundaryIndex >= 0) {
+      const snapshotIndex = sessionEntries.findIndex(
+        (candidate) => candidate.id === entry.id,
+      );
+      if (snapshotIndex < boundaryIndex) {
+        return null;
+      }
     }
+
+    return entry.data;
   }
   return null;
 };
@@ -95,9 +164,17 @@ export const evictAgentStore = async (
 
 export const restoreAgentStoreFromBranch = async (
   sessionId: string,
-  entries: SessionEntry[],
+  branchEntries: SessionEntry[],
+  sessionEntries: SessionEntry[] = branchEntries,
+  sessionStartedAt?: string,
+  isSubagentSession = false,
 ): Promise<void> => {
-  const snapshot = findSnapshot(entries);
+  const snapshot = findSnapshot(
+    branchEntries,
+    sessionEntries,
+    sessionStartedAt,
+    isSubagentSession,
+  );
   if (!snapshot) {
     return;
   }
@@ -107,18 +184,19 @@ export const restoreAgentStoreFromBranch = async (
     ? fromHex(snapshot.latestRootBlobId)
     : new Uint8Array();
 
-  if (rootBlobId.length > 0) {
-    await applySnapshotToStore(storeEntry, snapshot.agentId, rootBlobId);
-    return;
-  }
+  storeEntry.jsonStore.metadata.agentId = snapshot.agentId;
 
   if (snapshot.conversationState) {
-    storeEntry.jsonStore.metadata.agentId = snapshot.agentId;
     try {
-      storeEntry.store.conversationStateStructure =
-        ConversationStateStructure.fromBinary(
-          Buffer.from(snapshot.conversationState, "base64"),
-        );
+      const conversationState = ConversationStateStructure.fromBinary(
+        Buffer.from(snapshot.conversationState, "base64"),
+      );
+      await storeEntry.store.handleCheckpoint(null, conversationState);
+      return;
     } catch {}
+  }
+
+  if (rootBlobId.length > 0) {
+    await applySnapshotToStore(storeEntry, snapshot.agentId, rootBlobId);
   }
 };

--- a/pi-cursor-agent/src/provider/agent-stream-hook.ts
+++ b/pi-cursor-agent/src/provider/agent-stream-hook.ts
@@ -1,3 +1,4 @@
+import type { ConversationAction } from "../__generated__/agent/v1/agent_pb";
 import type { ToolExecRequest } from "../bridge/cursor-to-pi/tool-bridge";
 
 export type ChannelEvent =
@@ -51,6 +52,7 @@ export interface LiveSession {
   channel: LiveEventChannel;
   cursorRunPromise: Promise<void>;
   flushSessionState: () => Promise<void>;
+  sendConversationActions: (actions: ConversationAction[]) => Promise<void>;
   abort: (reason?: string) => void;
   startTime: number;
   firstTokenTime?: number;

--- a/pi-cursor-agent/src/provider/agent-stream-hook.ts
+++ b/pi-cursor-agent/src/provider/agent-stream-hook.ts
@@ -5,7 +5,8 @@ export type ChannelEvent =
   | { kind: "content"; data: ContentEvent }
   | { kind: "tool-exec-request"; request: ToolExecRequest }
   | { kind: "token-delta"; tokens: number }
-  | { kind: "cursor-done" };
+  | { kind: "cursor-done" }
+  | { kind: "cursor-error"; error: unknown };
 
 export interface ContentEvent {
   kind: "thinking-delta" | "text-delta" | "thinking-completed";

--- a/pi-cursor-agent/src/provider/stream.ts
+++ b/pi-cursor-agent/src/provider/stream.ts
@@ -30,6 +30,7 @@ import {
 } from "../bridge/cursor-to-pi/tool-bridge";
 import { preparePiContext } from "../bridge/pi-context";
 import {
+  buildContinuationActions,
   buildRunRequest,
   getContextTools,
 } from "../bridge/pi-to-cursor/request-builder";
@@ -59,6 +60,7 @@ import {
   setLiveSession,
 } from "./agent-stream-hook";
 import { toCursorId } from "./model-mapping";
+import { terminateSession } from "./session-lifecycle";
 import { type CursorStateStore, createOverlayState } from "./state";
 
 function createCheckpointHandler(
@@ -371,6 +373,24 @@ export function streamCursorAgent(
     try {
       session = getLiveSession(sessionId);
 
+      if (session) {
+        const continuationActions = buildContinuationActions(context);
+        if (continuationActions.length > 0) {
+          try {
+            await session.sendConversationActions(continuationActions);
+          } catch {
+            // Cursor may have completed after Pi stopped at a tool boundary.
+            // Preserve its checkpoint, retire the stale transport, and replay
+            // the new user action as the first action of a fresh connection.
+            await terminateSession(
+              sessionId,
+              "Restarting Cursor session for new input",
+            );
+            session = undefined;
+          }
+        }
+      }
+
       if (!session) {
         const apiKey = options?.apiKey;
         if (!apiKey) {
@@ -493,6 +513,8 @@ export function streamCursorAgent(
           channel,
           cursorRunPromise,
           flushSessionState,
+          sendConversationActions: (actions) =>
+            connectClient.sendConversationActions(actions),
           abort: (reason) => {
             sessionAbortController.abort(
               reason ? new Error(reason) : new Error("Session ended"),

--- a/pi-cursor-agent/src/provider/stream.ts
+++ b/pi-cursor-agent/src/provider/stream.ts
@@ -78,6 +78,31 @@ function createCheckpointHandler(
 }
 
 const QUERY_REJECTION_REASON = "Not supported";
+const ABORT_ERROR_NAME = "AbortError";
+const REQUEST_CANCELLED_MESSAGE = "Request cancelled";
+const SESSION_ENDED_MESSAGE = "Session ended";
+const REQUEST_ABORTED_MESSAGE = "Request aborted";
+
+function isAbortLikeError(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) {
+    return true;
+  }
+
+  if (error instanceof DOMException && error.name === ABORT_ERROR_NAME) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.name === ABORT_ERROR_NAME ||
+    error.message === REQUEST_CANCELLED_MESSAGE ||
+    error.message === SESSION_ENDED_MESSAGE ||
+    error.message === REQUEST_ABORTED_MESSAGE
+  );
+}
 
 function createInteractionListenerAdapter(
   onUpdate: (update: CoreInteractionUpdate) => void,
@@ -279,6 +304,13 @@ async function consumeUntilBoundary(
         finalizeAllContent(contentState, output, stream);
         return { reason: "stop", tools: [] };
       }
+
+      case "cursor-error": {
+        finalizeAllContent(contentState, output, stream);
+        throw event.error instanceof Error
+          ? event.error
+          : new Error(String(event.error));
+      }
     }
   }
 }
@@ -369,6 +401,7 @@ export function streamCursorAgent(
       timestamp: Date.now(),
     };
     let session: LiveSession | undefined;
+    let effectiveSignal = options?.signal;
 
     try {
       session = getLiveSession(sessionId);
@@ -408,6 +441,7 @@ export function streamCursorAgent(
         const sessionSignal = options?.signal
           ? AbortSignal.any([options.signal, sessionAbortController.signal])
           : sessionAbortController.signal;
+        effectiveSignal = sessionSignal;
 
         const piToolCtx: PiToolContext = {
           cwd,
@@ -506,7 +540,7 @@ export function streamCursorAgent(
         const cursorRunPromise = connectClient
           .run(initialRequest, runOptions)
           .then(() => channel.push({ kind: "cursor-done" }))
-          .catch(() => channel.push({ kind: "cursor-done" }))
+          .catch((error) => channel.push({ kind: "cursor-error", error }))
           .finally(() => channel.markDone());
 
         session = {
@@ -592,13 +626,14 @@ export function streamCursorAgent(
           flushed = true;
         } catch {}
         deleteLiveSession(sessionId);
-        await session.cursorRunPromise.catch(() => {});
+        await session.cursorRunPromise;
         await evictAgentStore(sessionId, { persist: !flushed }).catch(() => {});
         stream.push({ type: "done", reason: "stop", message: output });
       }
       stream.end();
     } catch (error) {
-      output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      const wasAborted = isAbortLikeError(error, effectiveSignal);
+      output.stopReason = wasAborted ? "aborted" : "error";
       output.errorMessage =
         error instanceof Error ? error.message : String(error);
       let flushed = false;
@@ -617,7 +652,7 @@ export function streamCursorAgent(
       await evictAgentStore(sessionId, { persist: !flushed }).catch(() => {});
       stream.push({
         type: "error",
-        reason: output.stopReason === "aborted" ? "aborted" : "error",
+        reason: wasAborted ? "aborted" : "error",
         error: { ...output },
       });
       stream.end();

--- a/pi-cursor-agent/src/vendor/agent-client/connect.ts
+++ b/pi-cursor-agent/src/vendor/agent-client/connect.ts
@@ -86,11 +86,70 @@ async function backoff(attempt: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
+interface PendingConversationAction {
+  key: string;
+  action: ConversationAction;
+}
+
+function getUserActionMessageId(
+  action: ConversationAction,
+): string | undefined {
+  if (action.action.case !== "userMessageAction") return undefined;
+  return action.action.value.userMessage?.messageId || undefined;
+}
+
+function getConversationActionKey(action: ConversationAction): string {
+  return getUserActionMessageId(action) ?? crypto.randomUUID();
+}
+
 export class AgentConnectClient {
   private readonly client: AgentRpcClient;
+  private readonly pendingConversationActions: PendingConversationAction[] = [];
+  private conversationActionWriter:
+    | ((action: ConversationAction) => Promise<void>)
+    | undefined;
 
   constructor(client: AgentRpcClient) {
     this.client = client;
+  }
+
+  async sendConversationAction(action: ConversationAction): Promise<void> {
+    await this.sendConversationActions([action]);
+  }
+
+  async sendConversationActions(actions: ConversationAction[]): Promise<void> {
+    const writer = this.conversationActionWriter;
+    if (!writer) {
+      throw new Error("Cursor conversation is not accepting new actions");
+    }
+
+    const pending: PendingConversationAction[] = [];
+    for (const action of actions) {
+      const key = getConversationActionKey(action);
+      if (this.pendingConversationActions.some((item) => item.key === key)) {
+        continue;
+      }
+      const item = { key, action };
+      this.pendingConversationActions.push(item);
+      pending.push(item);
+    }
+
+    for (const item of pending) {
+      try {
+        await writer(item.action);
+      } catch {
+        // Keep the action pending. The active run will either retry its
+        // transport or replay unacknowledged actions from the latest checkpoint.
+        return;
+      }
+    }
+  }
+
+  private acknowledgeUserMessage(messageId: string): void {
+    const index = this.pendingConversationActions.findIndex(
+      (item) => item.key === messageId,
+    );
+    if (index >= 0) this.pendingConversationActions.splice(index, 1);
   }
 
   /**
@@ -121,6 +180,8 @@ export class AgentConnectClient {
     const mcpTools = runRequest.mcpTools;
     const conversationId = runRequest.conversationId;
     let attempt = 0;
+    let unacknowledgedClosureKey: string | undefined;
+    let unacknowledgedClosureAttempts = 0;
     const receivedNewCheckpoint = { value: false };
 
     // Helper: switch to ResumeAction if we received a checkpoint
@@ -132,6 +193,20 @@ export class AgentConnectClient {
       currentAction = new ConversationAction({
         action: { case: "resumeAction", value: new ResumeAction() },
       });
+    };
+
+    const trackingInteractionListener: InteractionListener = {
+      sendUpdate: async (ctx, update) => {
+        if (update.type === "user-message-appended") {
+          const messageId = (update.userMessage as { messageId?: unknown })
+            .messageId;
+          if (typeof messageId === "string") {
+            this.acknowledgeUserMessage(messageId);
+          }
+        }
+        await options.interactionListener.sendUpdate(ctx, update);
+      },
+      query: (ctx, query) => options.interactionListener.query(ctx, query),
     };
 
     // Wrap checkpoint handler to track when we receive new checkpoints
@@ -167,9 +242,38 @@ export class AgentConnectClient {
 
         await this.runInternal(request, {
           ...options,
+          interactionListener: trackingInteractionListener,
           checkpointHandler: trackingCheckpointHandler,
         });
-        return;
+
+        const pending = this.pendingConversationActions[0];
+        if (!pending) return;
+
+        const checkpoint = options.checkpointHandler.getLatestCheckpoint?.();
+        if (!checkpoint) {
+          throw new Error(
+            "Cursor closed before acknowledging steering input and no checkpoint is available",
+          );
+        }
+
+        if (unacknowledgedClosureKey === pending.key) {
+          unacknowledgedClosureAttempts += 1;
+        } else {
+          unacknowledgedClosureKey = pending.key;
+          unacknowledgedClosureAttempts = 1;
+        }
+        if (unacknowledgedClosureAttempts > MAX_RETRY_ATTEMPTS) {
+          throw new Error(
+            "Cursor repeatedly closed before acknowledging steering input",
+          );
+        }
+
+        // Cursor closed before acknowledging this action. Re-open from its
+        // latest checkpoint with the same action and message ID as the initial
+        // action. Keep it pending until Cursor explicitly appends it.
+        currentState = checkpoint;
+        currentAction = pending.action;
+        attempt = 0;
       } catch (error) {
         if (!isRetriableError(error) || attempt >= MAX_RETRY_ATTEMPTS) {
           throw error;
@@ -224,6 +328,14 @@ export class AgentConnectClient {
 
     void baseRequestStream.write(initialRequest);
 
+    const conversationActionWriter = (action: ConversationAction) =>
+      baseRequestStream.write(
+        new AgentClientMessage({
+          message: { case: "conversationAction", value: action },
+        }),
+      );
+    this.conversationActionWriter = conversationActionWriter;
+
     const runOptions: {
       signal?: AbortSignal;
       headers?: Record<string, string>;
@@ -232,6 +344,16 @@ export class AgentConnectClient {
     if (options.headers) runOptions.headers = options.headers;
 
     const response = this.client.run(baseRequestStream, runOptions);
+    const initialAction = (initialRequest.message.value as AgentRunRequest)
+      .action;
+    const initialUserMessageId = initialAction
+      ? getUserActionMessageId(initialAction)
+      : undefined;
+
+    for (const pending of this.pendingConversationActions) {
+      if (pending.key === initialUserMessageId) continue;
+      void conversationActionWriter(pending.action).catch(() => {});
+    }
 
     const channels: SplitChannels = splitStream(response, stallDetector, () =>
       options.onConnectionStateChange?.({ state: "connected" }),
@@ -349,6 +471,9 @@ export class AgentConnectClient {
       }
     } finally {
       clearHeartbeat();
+      if (this.conversationActionWriter === conversationActionWriter) {
+        this.conversationActionWriter = undefined;
+      }
       baseRequestStream.close();
     }
   }

--- a/pi-cursor-agent/src/vendor/agent-client/connect.ts
+++ b/pi-cursor-agent/src/vendor/agent-client/connect.ts
@@ -91,6 +91,15 @@ interface PendingConversationAction {
   action: ConversationAction;
 }
 
+class ConversationActionRunClosed extends Error {
+  constructor() {
+    super("Cursor conversation run closed before accepting the action");
+    this.name = "ConversationActionRunClosed";
+  }
+}
+
+const RUN_CLOSED = Symbol("run-closed");
+
 function getUserActionMessageId(
   action: ConversationAction,
 ): string | undefined {
@@ -137,10 +146,13 @@ export class AgentConnectClient {
     for (const item of pending) {
       try {
         await writer(item.action);
-      } catch {
-        // Keep the action pending. The active run will either retry its
-        // transport or replay unacknowledged actions from the latest checkpoint.
-        return;
+      } catch (error) {
+        if (error instanceof ConversationActionRunClosed) {
+          // Keep the action pending. run() will replay it from the latest
+          // checkpoint when the cleanly closed attempt finishes.
+          return;
+        }
+        throw error;
       }
     }
   }
@@ -328,36 +340,32 @@ export class AgentConnectClient {
 
     void baseRequestStream.write(initialRequest);
 
-    const conversationActionWriter = (action: ConversationAction) =>
-      baseRequestStream.write(
-        new AgentClientMessage({
-          message: { case: "conversationAction", value: action },
-        }),
-      );
+    let runClosed = false;
+    let resolveRunClosed!: () => void;
+    const runClosedPromise = new Promise<typeof RUN_CLOSED>((resolve) => {
+      resolveRunClosed = () => resolve(RUN_CLOSED);
+    });
+    const conversationActionWriter = async (action: ConversationAction) => {
+      try {
+        const result = await Promise.race([
+          baseRequestStream.write(
+            new AgentClientMessage({
+              message: { case: "conversationAction", value: action },
+            }),
+          ),
+          runClosedPromise,
+        ]);
+        if (result === RUN_CLOSED) {
+          throw new ConversationActionRunClosed();
+        }
+      } catch (error) {
+        if (runClosed && !(error instanceof ConversationActionRunClosed)) {
+          throw new ConversationActionRunClosed();
+        }
+        throw error;
+      }
+    };
     this.conversationActionWriter = conversationActionWriter;
-
-    const runOptions: {
-      signal?: AbortSignal;
-      headers?: Record<string, string>;
-    } = {};
-    if (options.signal) runOptions.signal = options.signal;
-    if (options.headers) runOptions.headers = options.headers;
-
-    const response = this.client.run(baseRequestStream, runOptions);
-    const initialAction = (initialRequest.message.value as AgentRunRequest)
-      .action;
-    const initialUserMessageId = initialAction
-      ? getUserActionMessageId(initialAction)
-      : undefined;
-
-    for (const pending of this.pendingConversationActions) {
-      if (pending.key === initialUserMessageId) continue;
-      void conversationActionWriter(pending.action).catch(() => {});
-    }
-
-    const channels: SplitChannels = splitStream(response, stallDetector, () =>
-      options.onConnectionStateChange?.({ state: "connected" }),
-    );
 
     // Heartbeat sender using setTimeout (not setInterval)
     let heartbeatTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -385,9 +393,32 @@ export class AgentConnectClient {
       }
     };
 
-    scheduleHeartbeat();
-
     try {
+      const runOptions: {
+        signal?: AbortSignal;
+        headers?: Record<string, string>;
+      } = {};
+      if (options.signal) runOptions.signal = options.signal;
+      if (options.headers) runOptions.headers = options.headers;
+
+      const response = this.client.run(baseRequestStream, runOptions);
+      const initialAction = (initialRequest.message.value as AgentRunRequest)
+        .action;
+      const initialUserMessageId = initialAction
+        ? getUserActionMessageId(initialAction)
+        : undefined;
+
+      for (const pending of this.pendingConversationActions) {
+        if (pending.key === initialUserMessageId) continue;
+        void conversationActionWriter(pending.action).catch(() => {});
+      }
+
+      const channels: SplitChannels = splitStream(response, stallDetector, () =>
+        options.onConnectionStateChange?.({ state: "connected" }),
+      );
+
+      scheduleHeartbeat();
+
       const execOutputStream = new MapWritable<
         ExecClientMessage | ExecClientControlMessage,
         AgentClientMessage
@@ -471,6 +502,8 @@ export class AgentConnectClient {
       }
     } finally {
       clearHeartbeat();
+      runClosed = true;
+      resolveRunClosed();
       if (this.conversationActionWriter === conversationActionWriter) {
         this.conversationActionWriter = undefined;
       }

--- a/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
+++ b/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
@@ -17,9 +17,7 @@ function errResult(text: string): ToolResultMessage {
 test("ENOENT maps to ReadResult fileNotFound", () => {
   const r = buildReadResultFromToolResult(
     "missing.txt",
-    errResult(
-      "ENOENT: no such file or directory, access '/tmp/missing.txt'",
-    ),
+    errResult("ENOENT: no such file or directory, access '/tmp/missing.txt'"),
   );
   assert.equal(r.result.case, "fileNotFound");
   if (r.result.case === "fileNotFound") {

--- a/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
+++ b/pi-cursor-agent/test/bridge/cursor-to-pi/read-result-from-tool-result.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { buildReadResultFromToolResult } from "../../../src/bridge/cursor-to-pi/executors/read.js";
+
+function errResult(text: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "t1",
+    toolName: "read",
+    content: [{ type: "text", text }],
+    isError: true,
+    timestamp: 1,
+  };
+}
+
+test("ENOENT maps to ReadResult fileNotFound", () => {
+  const r = buildReadResultFromToolResult(
+    "missing.txt",
+    errResult(
+      "ENOENT: no such file or directory, access '/tmp/missing.txt'",
+    ),
+  );
+  assert.equal(r.result.case, "fileNotFound");
+  if (r.result.case === "fileNotFound") {
+    assert.equal(r.result.value.path, "missing.txt");
+  }
+});
+
+test("generic read error stays ReadError", () => {
+  const r = buildReadResultFromToolResult(
+    "x.txt",
+    errResult("Something else went wrong"),
+  );
+  assert.equal(r.result.case, "error");
+  if (r.result.case === "error") {
+    assert.match(r.result.value.error, /Something else/);
+  }
+});

--- a/pi-cursor-agent/test/bridge/pi-context/parser.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-context/parser.test.ts
@@ -80,11 +80,43 @@ test("cleanedPrompt keeps metadata and Pi documentation", () => {
     }),
   );
 
+  assert.ok(
+    result.cleanedPrompt.includes("You are an expert coding assistant."),
+  );
   assert.ok(result.cleanedPrompt.includes("Current date:"));
   assert.ok(result.cleanedPrompt.includes("Current working directory:"));
   assert.ok(result.cleanedPrompt.includes("Pi documentation"));
   assert.ok(result.cleanedPrompt.includes("- Main documentation:"));
   assert.ok(!result.cleanedPrompt.includes("Available tools:"));
+});
+
+test("cleanedPrompt preserves custom agent instructions", () => {
+  const contract = [
+    "You are `figma-scout`, a read-only Figma evidence agent.",
+    "",
+    "## Boundaries",
+    "",
+    "Inspect Figma only and never mutate the document.",
+  ].join("\n");
+  const generated = buildPrompt({
+    contextFiles: [{ path: "/AGENTS.md", content: "Project rules." }],
+    skills: [
+      {
+        name: "ask-user",
+        description: "Ask focused questions.",
+        location: "/SKILL.md",
+      },
+    ],
+  });
+  const result = parsePiSystemPrompt(
+    generated.replace("You are an expert coding assistant.", contract),
+  );
+
+  assert.ok(result.cleanedPrompt.includes(contract));
+  assert.ok(!result.cleanedPrompt.includes("Available tools:"));
+  assert.ok(!result.cleanedPrompt.includes("Project rules."));
+  assert.ok(!result.cleanedPrompt.includes("<available_skills>"));
+  assert.ok(result.cleanedPrompt.includes("Current working directory:"));
 });
 
 test("returns empty for prompt without context or skills", () => {

--- a/pi-cursor-agent/test/bridge/pi-context/rules-builder.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-context/rules-builder.test.ts
@@ -19,6 +19,20 @@ function parsed(overrides: Partial<ParsedPiContext> = {}): ParsedPiContext {
   return { contextFiles: [], skills: [], cleanedPrompt: "", ...overrides };
 }
 
+test("cleaned system prompt becomes an always-applied global rule", async () => {
+  const rules = await buildCursorRules(
+    parsed({ cleanedPrompt: "You are figma-scout.\n\nFollow the contract." }),
+  );
+
+  assert.equal(rules.length, 1);
+  assert.equal(rules[0]?.fullPath, "/__pi__/system-prompt.md");
+  assert.equal(rules[0]?.type?.type.case, "global");
+  assert.equal(
+    rules[0]?.content,
+    "You are figma-scout.\n\nFollow the contract.",
+  );
+});
+
 test("context files become global rules, skills become agentFetched rules", async () => {
   await withTempDir(async (dir) => {
     const skillPath = join(dir, "SKILL.md");

--- a/pi-cursor-agent/test/bridge/pi-to-cursor/request-builder.test.ts
+++ b/pi-cursor-agent/test/bridge/pi-to-cursor/request-builder.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { Context, Message, Model } from "@mariozechner/pi-ai";
 import { ConversationStateStructure } from "../../../src/__generated__/agent/v1/agent_pb.js";
-import { buildRunRequest } from "../../../src/bridge/pi-to-cursor/request-builder.js";
+import {
+  buildContinuationActions,
+  buildRunRequest,
+} from "../../../src/bridge/pi-to-cursor/request-builder.js";
 import { createStateStore } from "../../../src/provider/state.js";
 import {
   getBlobId,
@@ -64,6 +67,82 @@ function createParams(options?: {
     },
   };
 }
+
+test("builds continuation actions for all trailing steering input", () => {
+  const context = {
+    messages: [
+      { role: "user", content: "Start searching", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [],
+        timestamp: 2,
+        ...ASSISTANT_DEFAULTS,
+      },
+      { role: "user", content: "slow down", timestamp: 3 },
+      { role: "user", content: "stop", timestamp: 4 },
+    ],
+  } satisfies Context;
+
+  const actions = buildContinuationActions(context);
+  assert.equal(actions.length, 2);
+  const texts = actions.map((action) => {
+    assert.equal(action.action.case, "userMessageAction");
+    if (action.action.case !== "userMessageAction") {
+      assert.fail("Expected a user message action");
+    }
+    return action.action.value.userMessage?.text;
+  });
+  assert.deepEqual(texts, ["slow down", "stop"]);
+});
+
+test("does not build a continuation action after a tool result", () => {
+  const context = {
+    messages: [
+      { role: "user", content: "Read a.ts", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [],
+        timestamp: 2,
+        ...ASSISTANT_DEFAULTS,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tc-1",
+        toolName: "read",
+        content: [{ type: "text", text: "const x = 1;" }],
+        isError: false,
+        timestamp: 3,
+      },
+    ],
+  } satisfies Context;
+
+  assert.deepEqual(buildContinuationActions(context), []);
+});
+
+test("preserves every trailing user message when starting a run", () => {
+  const { params } = createParams({
+    messages: [
+      { role: "user", content: "push to github", timestamp: 1 },
+      { role: "user", content: "hidden roster context", timestamp: 2 },
+    ],
+  });
+
+  const result = buildRunRequest(params);
+  assert.equal(result.initialRequest.message.case, "runRequest");
+  if (result.initialRequest.message.case !== "runRequest") {
+    assert.fail("Expected a run request");
+  }
+  const initialAction = result.initialRequest.message.value.action;
+  assert.equal(initialAction?.action.case, "userMessageAction");
+  if (initialAction?.action.case !== "userMessageAction") {
+    assert.fail("Expected a user message action");
+  }
+  assert.equal(
+    initialAction.action.value.userMessage?.text,
+    "push to github\n\nhidden roster context",
+  );
+  assert.equal(result.conversationState.turns.length, 0);
+});
 
 test("preserves cached conversation state", () => {
   const bytes = new TextEncoder().encode(

--- a/pi-cursor-agent/test/provider/agent-store.test.ts
+++ b/pi-cursor-agent/test/provider/agent-store.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionEntry } from "@mariozechner/pi-coding-agent";
+import { ConversationStateStructure } from "../../src/__generated__/agent/v1/agent_pb.js";
+import {
+  ensureAgentStore,
+  evictAgentStore,
+  isExternallyManagedSubagentSession,
+  restoreAgentStoreFromBranch,
+} from "../../src/provider/agent-store.js";
+
+const SNAPSHOT_TYPE = "pi-cursor-agent:state";
+const SUBAGENT_BOUNDARY_TYPE = "subagent_boundary";
+const SUBAGENT_MARKER_TYPE = "pi-subagents_launch_metadata";
+const SESSION_STARTED_AT = "2026-01-02T00:00:00.000Z";
+const AFTER_SESSION_START = "2026-01-02T00:00:01.000Z";
+const BEFORE_SESSION_START = "2026-01-01T00:00:00.000Z";
+
+interface BranchEntry {
+  id: string;
+  type: string;
+  customType?: string;
+  data?: unknown;
+  timestamp?: string;
+}
+
+function snapshot(
+  agentId: string,
+  options: { root?: string; promptByte?: number } = {},
+): BranchEntry {
+  const state = new ConversationStateStructure({
+    rootPromptMessagesJson: [new Uint8Array([options.promptByte ?? 1])],
+  });
+  return {
+    id: `snapshot-${agentId}`,
+    type: "custom",
+    customType: SNAPSHOT_TYPE,
+    data: {
+      version: 1,
+      agentId,
+      latestRootBlobId: options.root ?? "",
+      conversationState: Buffer.from(state.toBinary()).toString("base64"),
+    },
+  };
+}
+
+function subagentBoundary(id: string = crypto.randomUUID()): BranchEntry {
+  return {
+    id,
+    type: "custom_message",
+    customType: SUBAGENT_BOUNDARY_TYPE,
+  };
+}
+
+function subagentMarker(
+  id: string = crypto.randomUUID(),
+  timestamp = AFTER_SESSION_START,
+): BranchEntry {
+  return {
+    id,
+    type: "custom",
+    customType: SUBAGENT_MARKER_TYPE,
+    data: {},
+    timestamp,
+  };
+}
+
+async function withStore(
+  branchEntries: BranchEntry[],
+  sessionEntries: BranchEntry[],
+  verify: (store: Awaited<ReturnType<typeof ensureAgentStore>>) => void,
+  sessionStartedAt?: string,
+  isSubagentSession = false,
+): Promise<void> {
+  const sessionId = crypto.randomUUID();
+
+  try {
+    await restoreAgentStoreFromBranch(
+      sessionId,
+      branchEntries as SessionEntry[],
+      sessionEntries as SessionEntry[],
+      sessionStartedAt,
+      isSubagentSession,
+    );
+    verify(await ensureAgentStore(sessionId));
+  } finally {
+    await evictAgentStore(sessionId, { persist: false });
+  }
+}
+
+test("ignores inherited snapshots before launch metadata becomes visible", async () => {
+  const parentSnapshot = snapshot("parent-agent");
+  const isManagedSubagentSession = isExternallyManagedSubagentSession(
+    "/sessions/managed-subagent.jsonl",
+    "/sessions/child/../managed-subagent.jsonl",
+  );
+
+  assert.equal(isManagedSubagentSession, true);
+  await withStore(
+    [parentSnapshot],
+    [parentSnapshot],
+    (store) => {
+      assert.notEqual(store.getId(), "parent-agent");
+      assert.equal(
+        store.getConversationStateStructure().rootPromptMessagesJson.length,
+        0,
+      );
+    },
+    SESSION_STARTED_AT,
+    isManagedSubagentSession,
+  );
+});
+
+test("ignores inherited snapshots in boundary-disabled subagent sessions", async () => {
+  for (const root of ["", "01020304"]) {
+    const parentSnapshot = snapshot("parent-agent", { root });
+    const sessionEntries = [parentSnapshot, subagentMarker()];
+
+    await withStore(
+      [parentSnapshot],
+      sessionEntries,
+      (store) => {
+        assert.notEqual(store.getId(), "parent-agent");
+        assert.equal(
+          store.getConversationStateStructure().rootPromptMessagesJson.length,
+          0,
+        );
+      },
+      SESSION_STARTED_AT,
+      true,
+    );
+  }
+});
+
+test("restores a child snapshot after resume metadata is appended", async () => {
+  const childSnapshot = snapshot("child-agent", { promptByte: 2 });
+  const entries = [
+    snapshot("parent-agent"),
+    subagentBoundary(),
+    subagentMarker("initial-launch"),
+    childSnapshot,
+    subagentMarker("resume-override", "2026-01-02T00:00:03.000Z"),
+  ];
+
+  await withStore(
+    entries,
+    entries,
+    (store) => {
+      assert.equal(store.getId(), "child-agent");
+      assert.deepEqual(
+        Array.from(
+          store.getConversationStateStructure().rootPromptMessagesJson[0] ?? [],
+        ),
+        [2],
+      );
+    },
+    SESSION_STARTED_AT,
+    true,
+  );
+});
+
+test("restores ordinary forks opened inside a subagent process", async () => {
+  const entries = [snapshot("fork-agent", { root: "01020304", promptByte: 9 })];
+  const isManagedSubagentSession = isExternallyManagedSubagentSession(
+    "/sessions/ordinary-fork.jsonl",
+    "/sessions/managed-subagent.jsonl",
+  );
+
+  assert.equal(isManagedSubagentSession, false);
+  await withStore(
+    entries,
+    entries,
+    (store) => {
+      assert.equal(store.getId(), "fork-agent");
+      assert.deepEqual(
+        Array.from(
+          store.getConversationStateStructure().rootPromptMessagesJson[0] ?? [],
+        ),
+        [9],
+      );
+    },
+    SESSION_STARTED_AT,
+    isManagedSubagentSession,
+  );
+});
+
+test("the current launch marker partitions boundary-disabled nested forks", async () => {
+  const firstChildSnapshot = snapshot("first-child");
+  const entries = [
+    subagentBoundary("inherited-boundary"),
+    subagentMarker("inherited-launch", BEFORE_SESSION_START),
+    firstChildSnapshot,
+    subagentMarker("nested-launch"),
+  ];
+
+  await withStore(
+    [firstChildSnapshot],
+    entries,
+    (store) => {
+      assert.notEqual(store.getId(), "first-child");
+      assert.equal(
+        store.getConversationStateStructure().rootPromptMessagesJson.length,
+        0,
+      );
+    },
+    SESSION_STARTED_AT,
+    true,
+  );
+});

--- a/pi-cursor-agent/test/provider/session-lifecycle.test.ts
+++ b/pi-cursor-agent/test/provider/session-lifecycle.test.ts
@@ -28,6 +28,7 @@ function createLiveSession(label: string) {
     channel: new LiveEventChannel(label),
     cursorRunPromise: Promise.resolve(),
     flushSessionState: async () => {},
+    sendConversationActions: async () => {},
     abort: () => {},
     startTime: Date.now(),
   };
@@ -84,6 +85,7 @@ test("terminateSession aborts the live session and rejects pending tool results"
     flushSessionState: async () => {
       flushed += 1;
     },
+    sendConversationActions: async () => {},
     abort: (reason?: string) => {
       abortReason = reason;
       resolveRun();

--- a/pi-cursor-agent/test/vendor/agent-client/connect.test.ts
+++ b/pi-cursor-agent/test/vendor/agent-client/connect.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AgentClientMessage,
+  AgentRunRequest,
+  AgentServerMessage,
+  ConversationAction,
+  ConversationStateStructure,
+  InteractionUpdate,
+  UserMessage,
+  UserMessageAction,
+  UserMessageAppendedUpdate,
+} from "../../../src/__generated__/agent/v1/agent_pb.js";
+import {
+  AgentConnectClient,
+  type AgentRpcClient,
+} from "../../../src/vendor/agent-client/connect.js";
+import { LostConnection } from "../../../src/vendor/agent-client/exec-controller.js";
+import { InMemoryBlobStore } from "../../../src/vendor/agent-kv/index.js";
+
+function userAction(text: string): ConversationAction {
+  return new ConversationAction({
+    action: {
+      case: "userMessageAction",
+      value: new UserMessageAction({
+        userMessage: new UserMessage({ text, messageId: crypto.randomUUID() }),
+      }),
+    },
+  });
+}
+
+function getUserMessage(action: ConversationAction): UserMessage {
+  assert.equal(action.action.case, "userMessageAction");
+  if (action.action.case !== "userMessageAction") {
+    assert.fail("Expected a user message action");
+  }
+  const message = action.action.value.userMessage;
+  assert.ok(message);
+  return message;
+}
+
+function getConversationAction(
+  message: AgentClientMessage,
+): ConversationAction {
+  assert.equal(message.message.case, "conversationAction");
+  if (message.message.case !== "conversationAction") {
+    assert.fail("Expected a conversation action");
+  }
+  return message.message.value;
+}
+
+function appendedMessage(userMessage: UserMessage): AgentServerMessage {
+  return new AgentServerMessage({
+    message: {
+      case: "interactionUpdate",
+      value: new InteractionUpdate({
+        message: {
+          case: "userMessageAppended",
+          value: new UserMessageAppendedUpdate({ userMessage }),
+        },
+      }),
+    },
+  });
+}
+
+function createRunOptions() {
+  let latestCheckpoint: ConversationStateStructure | undefined;
+  return {
+    interactionListener: {
+      async sendUpdate() {},
+      async query() {
+        return { approved: false, reason: "Not supported" };
+      },
+    },
+    resources: { entries: () => [] },
+    blobStore: new InMemoryBlobStore(),
+    checkpointHandler: {
+      async handleCheckpoint(
+        _ctx: unknown,
+        checkpoint: ConversationStateStructure,
+      ) {
+        latestCheckpoint = checkpoint;
+      },
+      getLatestCheckpoint: () => latestCheckpoint,
+    },
+  };
+}
+
+function initialRequest(): AgentClientMessage {
+  return new AgentClientMessage({
+    message: {
+      case: "runRequest",
+      value: new AgentRunRequest({ action: userAction("start") }),
+    },
+  });
+}
+
+test("sends multiple conversation actions in order over an active run", async () => {
+  const received: AgentClientMessage[] = [];
+  const rpcClient: AgentRpcClient = {
+    run(input) {
+      return (async function* () {
+        for await (const message of input) {
+          received.push(message);
+          if (message.message.case !== "conversationAction") continue;
+          yield appendedMessage(getUserMessage(message.message.value));
+          if (
+            received.filter(
+              (item) => item.message.case === "conversationAction",
+            ).length === 2
+          ) {
+            return;
+          }
+        }
+      })();
+    },
+  };
+
+  const client = new AgentConnectClient(rpcClient);
+  const runPromise = client.run(initialRequest(), createRunOptions());
+  await client.sendConversationActions([
+    userAction("slow down"),
+    userAction("stop"),
+  ]);
+  await runPromise;
+
+  assert.deepEqual(
+    received.map((message) => message.message.case),
+    ["runRequest", "conversationAction", "conversationAction"],
+  );
+  assert.deepEqual(
+    received
+      .slice(1)
+      .map((message) => getUserMessage(getConversationAction(message)).text),
+    ["slow down", "stop"],
+  );
+});
+
+test("keeps replaying the same action id across clean stream closures", async () => {
+  const action = userAction("stop");
+  const expectedMessageId = getUserMessage(action).messageId;
+  const receivedMessageIds: string[] = [];
+  let attempt = 0;
+
+  const client = new AgentConnectClient({
+    run(input) {
+      attempt += 1;
+      const currentAttempt = attempt;
+      return (async function* () {
+        for await (const message of input) {
+          if (message.message.case === "conversationAction") {
+            const userMessage = getUserMessage(message.message.value);
+            receivedMessageIds.push(userMessage.messageId);
+            yield new AgentServerMessage({
+              message: {
+                case: "conversationCheckpointUpdate",
+                value: new ConversationStateStructure({
+                  rootPromptMessagesJson: [new Uint8Array([1])],
+                }),
+              },
+            });
+            return;
+          }
+
+          if (
+            currentAttempt >= 2 &&
+            message.message.case === "runRequest" &&
+            message.message.value.action
+          ) {
+            const userMessage = getUserMessage(message.message.value.action);
+            receivedMessageIds.push(userMessage.messageId);
+            if (currentAttempt === 2) {
+              yield new AgentServerMessage({
+                message: {
+                  case: "conversationCheckpointUpdate",
+                  value: new ConversationStateStructure({
+                    rootPromptMessagesJson: [new Uint8Array([2])],
+                  }),
+                },
+              });
+              return;
+            }
+            yield appendedMessage(userMessage);
+            return;
+          }
+        }
+      })();
+    },
+  });
+
+  const runPromise = client.run(initialRequest(), createRunOptions());
+  await client.sendConversationAction(action);
+  await runPromise;
+
+  assert.equal(attempt, 3);
+  assert.deepEqual(receivedMessageIds, [
+    expectedMessageId,
+    expectedMessageId,
+    expectedMessageId,
+  ]);
+});
+
+test("replays pending actions after a transport retry", async () => {
+  const action = userAction("stop");
+  const expectedMessageId = getUserMessage(action).messageId;
+  const receivedMessageIds: string[] = [];
+  let attempt = 0;
+
+  const client = new AgentConnectClient({
+    run(input) {
+      attempt += 1;
+      const currentAttempt = attempt;
+      return (async function* () {
+        for await (const message of input) {
+          if (message.message.case !== "conversationAction") continue;
+          const userMessage = getUserMessage(message.message.value);
+          receivedMessageIds.push(userMessage.messageId);
+          if (currentAttempt === 1) {
+            throw new LostConnection("test disconnect");
+          }
+          yield appendedMessage(userMessage);
+          return;
+        }
+      })();
+    },
+  });
+
+  const runPromise = client.run(initialRequest(), createRunOptions());
+  await client.sendConversationAction(action);
+  await runPromise;
+
+  assert.equal(attempt, 2);
+  assert.deepEqual(receivedMessageIds, [expectedMessageId, expectedMessageId]);
+});
+
+test("rejects conversation actions when no run is active", async () => {
+  const client = new AgentConnectClient({
+    run() {
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      };
+    },
+  });
+
+  await assert.rejects(
+    client.sendConversationAction(userAction("stop")),
+    /not accepting new actions/,
+  );
+});

--- a/pi-cursor-agent/test/vendor/agent-client/connect.test.ts
+++ b/pi-cursor-agent/test/vendor/agent-client/connect.test.ts
@@ -200,6 +200,132 @@ test("keeps replaying the same action id across clean stream closures", async ()
   ]);
 });
 
+test("settles a queued steer when its run closes before consuming it", async () => {
+  const action = userAction("planner is done");
+  const expectedMessageId = getUserMessage(action).messageId;
+  const receivedMessageIds: string[] = [];
+  let attempt = 0;
+  let markFirstRequestRead!: () => void;
+  let closeFirstRun!: () => void;
+  const firstRequestRead = new Promise<void>((resolve) => {
+    markFirstRequestRead = resolve;
+  });
+  const firstRunCanClose = new Promise<void>((resolve) => {
+    closeFirstRun = resolve;
+  });
+
+  const client = new AgentConnectClient({
+    run(input) {
+      attempt += 1;
+      const currentAttempt = attempt;
+      if (currentAttempt === 1) {
+        return (async function* () {
+          // Read manually so clean response closure does not call return() on
+          // the request iterator. ConnectRPC 1.7 behaves this way and leaves a
+          // queued write pending unless the client races it with run closure.
+          const iterator = input[Symbol.asyncIterator]();
+          const { value: message } = await iterator.next();
+          assert.equal(message?.message.case, "runRequest");
+          markFirstRequestRead();
+          yield new AgentServerMessage({
+            message: {
+              case: "conversationCheckpointUpdate",
+              value: new ConversationStateStructure({
+                rootPromptMessagesJson: [new Uint8Array([1])],
+              }),
+            },
+          });
+          await firstRunCanClose;
+        })();
+      }
+
+      return (async function* () {
+        for await (const message of input) {
+          assert.equal(message.message.case, "runRequest");
+          if (
+            message.message.case !== "runRequest" ||
+            !message.message.value.action
+          ) {
+            assert.fail("Expected a replayed run action");
+          }
+          const userMessage = getUserMessage(message.message.value.action);
+          receivedMessageIds.push(userMessage.messageId);
+          yield appendedMessage(userMessage);
+          return;
+        }
+      })();
+    },
+  });
+
+  const runPromise = client.run(initialRequest(), createRunOptions());
+  await firstRequestRead;
+  const sendPromise = client.sendConversationAction(action);
+  closeFirstRun();
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.all([sendPromise, runPromise]),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(new Error("queued steer did not settle after run close")),
+          500,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+
+  assert.equal(attempt, 2);
+  assert.deepEqual(receivedMessageIds, [expectedMessageId]);
+});
+
+test("propagates conversation-action write failures while the run is active", async () => {
+  let markWriterFailed!: () => void;
+  let finishRun!: () => void;
+  const writerFailed = new Promise<void>((resolve) => {
+    markWriterFailed = resolve;
+  });
+  const runCanFinish = new Promise<void>((resolve) => {
+    finishRun = resolve;
+  });
+
+  const client = new AgentConnectClient({
+    run(input) {
+      let finished = false;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (finished) return { done: true as const, value: undefined };
+              finished = true;
+              const iterator = input[Symbol.asyncIterator]();
+              const { value: message } = await iterator.next();
+              assert.equal(message?.message.case, "runRequest");
+              await iterator.return?.();
+              markWriterFailed();
+              await runCanFinish;
+              return { done: true as const, value: undefined };
+            },
+          };
+        },
+      };
+    },
+  });
+
+  const runPromise = client.run(initialRequest(), createRunOptions());
+  await writerFailed;
+  await assert.rejects(
+    client.sendConversationAction(userAction("stop")),
+    /WritableIterable already closed/,
+  );
+
+  finishRun();
+  await assert.rejects(runPromise, /no checkpoint is available/);
+});
+
 test("replays pending actions after a transport retry", async () => {
   const action = userAction("stop");
   const expectedMessageId = getUserMessage(action).messageId;
@@ -231,6 +357,23 @@ test("replays pending actions after a transport retry", async () => {
 
   assert.equal(attempt, 2);
   assert.deepEqual(receivedMessageIds, [expectedMessageId, expectedMessageId]);
+});
+
+test("clears the conversation-action writer after synchronous RPC setup failure", async () => {
+  const client = new AgentConnectClient({
+    run() {
+      throw new Error("synchronous RPC setup failure");
+    },
+  });
+
+  await assert.rejects(
+    client.run(initialRequest(), createRunOptions()),
+    /synchronous RPC setup failure/,
+  );
+  await assert.rejects(
+    client.sendConversationAction(userAction("stop")),
+    /not accepting new actions/,
+  );
 });
 
 test("rejects conversation actions when no run is active", async () => {


### PR DESCRIPTION
## Summary
- forward Pi steering and extension-triggered user messages into an active Cursor run through `conversationAction`
- replay unacknowledged actions with stable message IDs across transport retries and clean stream closures without blocking on a closed writer
- preserve complete trailing user/custom context when a fresh Cursor connection is required
- surface Cursor run failures through the live event channel and classify cancellation separately from provider errors
- isolate forked subagents from inherited Cursor conversations while preserving resumes, nested launches, and ordinary forks

## Test plan
- [x] `npm test` (51 tests)
- [x] Biome checks on all changed files
- [x] live RPC steering tests with Grok 4.5 High
- [x] live subagent test with exactly two scouts and one worker; all returned non-empty results and the parent emitted `LOCAL_WORKER_TEST_PASSED`
- [x] verified the forked worker received a distinct Cursor agent ID
- [ ] `npm run typecheck` — blocked by the existing `session_switch` peer-API mismatch in `src/index.ts`

Closes #18
Closes #27

Supersedes #28.