### PR TITLE
fix(pi-cursor-agent): keep refresh credential across token exchange

### DIFF
--- a/pi-cursor-agent/src/lib/auth.ts
+++ b/pi-cursor-agent/src/lib/auth.ts
@@ -43,11 +43,19 @@ class AuthManager {
     }
 
     try {
-      const { accessToken, refreshToken } = await this.auth.exchangeUserApiKey({
+      const { accessToken } = await this.auth.exchangeUserApiKey({
         token: credentials.refresh || credentials.access,
       });
       const expires = getTokenExpiry(accessToken);
-      return { access: accessToken, refresh: refreshToken, expires };
+      // Keep the original refresh credential: exchangeUserApiKey returns a
+      // JWT that cannot be used for a subsequent exchange. The stored
+      // refresh value (e.g. a long-lived `crsr_` API key) is the only
+      // credential that stays valid across refreshes.
+      return {
+        access: accessToken,
+        refresh: credentials.refresh,
+        expires,
+      };
     } catch {
       // If the refresh token is invalid, try to refresh it with access token
       if (credentials.access && credentials.refresh) {

--- a/pi-cursor-agent/test/lib/auth.test.ts
+++ b/pi-cursor-agent/test/lib/auth.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type Auth from "../../src/api/auth.js";
+import AuthManager from "../../src/lib/auth.js";
+
+class MockAuth {
+  lastToken = "";
+  result: { accessToken: string; refreshToken: string } | null = null;
+  error: Error | null = null;
+
+  async exchangeUserApiKey({ token }: { token: string }) {
+    this.lastToken = token;
+    if (this.error) {
+      throw this.error;
+    }
+    if (!this.result) {
+      throw new Error("exchangeUserApiKey called without a mocked result");
+    }
+    return this.result;
+  }
+
+  async poll() {
+    throw new Error("poll not mocked");
+  }
+}
+
+// A JWT with a known exp (in seconds). Payload: { exp: 2000000000 }
+const ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIwMDAwMDAwMDB9.c2ln";
+const NEW_REFRESH_TOKEN = "refresh-returned-by-exchange";
+
+test("refresh keeps the original refresh credential and returns new access", async () => {
+  const mockAuth = new MockAuth();
+  mockAuth.result = {
+    accessToken: ACCESS_TOKEN,
+    refreshToken: NEW_REFRESH_TOKEN,
+  };
+  const manager = new AuthManager(
+    mockAuth as unknown as Auth,
+    "https://cursor.com",
+  );
+
+  const credentials = {
+    access: "old-access",
+    refresh: "crsr_test-api-key",
+  };
+  const result = await manager.refresh(credentials);
+
+  // The exchange is always performed with the stored refresh credential.
+  assert.equal(mockAuth.lastToken, "crsr_test-api-key");
+  // Access token comes from the exchange response...
+  assert.equal(result.access, ACCESS_TOKEN);
+  // ...but the stored refresh credential is preserved instead of being
+  // replaced by the JWT returned from the exchange.
+  assert.equal(result.refresh, "crsr_test-api-key");
+  // Expiry is derived from the JWT exp (minus the 5-minute safety margin).
+  assert.equal(result.expires, 2000000000 * 1000 - 5 * 60 * 1000);
+});
+
+test("refresh falls back to the access token when only access is present", async () => {
+  const mockAuth = new MockAuth();
+  mockAuth.result = {
+    accessToken: ACCESS_TOKEN,
+    refreshToken: NEW_REFRESH_TOKEN,
+  };
+  const manager = new AuthManager(
+    mockAuth as unknown as Auth,
+    "https://cursor.com",
+  );
+
+  const credentials = { access: "old-access", refresh: "" };
+  const result = await manager.refresh(credentials);
+
+  assert.equal(mockAuth.lastToken, "old-access");
+  assert.equal(result.access, ACCESS_TOKEN);
+  assert.equal(result.refresh, "");
+});
+
+test("refresh rethrows with a descriptive error when both credentials fail", async () => {
+  const mockAuth = new MockAuth();
+  mockAuth.error = new Error("Invalid User API Key");
+  const manager = new AuthManager(
+    mockAuth as unknown as Auth,
+    "https://cursor.com",
+  );
+
+  await assert.rejects(
+    manager.refresh({ access: "acc", refresh: "rej" }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, "Failed to refresh credentials");
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Problem

With `pi-cursor-agent`, the OAuth refresh flow breaks permanently after the first access-token expiry:

1. `AuthManager.refresh` calls `exchange_user_api_key` with the stored refresh credential and receives a new **JWT** access + refresh pair.
2. The JWT refresh token is stored back as the refresh credential.
3. On the next expiry, `exchange_user_api_key` is called with that JWT, but **the endpoint only accepts a `crsr_` API key** (or the original stored value). It returns `401 Invalid User API Key`.
4. Every subsequent refresh fails, so pi reports `OAuth refresh failed for cursor-agent`.

Verified against `https://api2.cursor.sh/auth/exchange_user_api_key`:

| Credential sent as Bearer | Result |
|---|---|
| `crsr_...` API key | `200` |
| JWT access token | `401 Invalid User API Key` |
| JWT refresh token | `401 Invalid User API Key` |

## Fix

Preserve the original refresh credential when returning refreshed tokens instead of replacing it with the JWT returned by the exchange. A stored `crsr_` API key stays valid across refreshes, so the flow recovers automatically after each access-token expiry.

## Tests

Added `test/lib/auth.test.ts` covering:
- happy path: refresh returns the new access token while keeping the stored `crsr_` refresh credential (and asserts the exchange is invoked with it)
- access-only fallback path
- failure path (both credentials fail → descriptive error)

## Verification

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ (37 pass, including the 3 new tests)
- End-to-end: token forced to expired state, then a request to `cursor-agent/composer-2.5` succeeded and `auth.json` was refreshed (`expires` updated, refresh credential unchanged).